### PR TITLE
rename sigs.k8s.io/oci-proxy => k8s.io/registry.k8s.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # registry.k8s.io
 
-The production redirector service for Kubernetes container image artifacts, for more see [cmd/archeio](./cmd/archeio/README.md)
+This project implements the backend for registry.k8s.io, Kubernetes's container
+image registry.
+
+For more see [cmd/archeio](./cmd/archeio/README.md)
 
 ## Community, discussion, contribution, and support
 
@@ -8,7 +11,7 @@ Learn how to engage with the Kubernetes community on the [community page](http:/
 
 You can reach the maintainers of this project at:
 
-- [Slack](http://slack.k8s.io/)
+- [Slack](http://slack.k8s.io/) in channel `#sig-k8s-infra`
 - [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-sig-k8s-infra)
 
 ### Code of conduct

--- a/cmd/archeio/app/buckets_test.go
+++ b/cmd/archeio/app/buckets_test.go
@@ -19,7 +19,7 @@ package app
 import (
 	"testing"
 
-	"sigs.k8s.io/oci-proxy/pkg/net/cidrs/aws"
+	"k8s.io/registry.k8s.io/pkg/net/cidrs/aws"
 )
 
 func TestRegionToAWSRegionToS3URL(t *testing.T) {

--- a/cmd/archeio/app/handlers.go
+++ b/cmd/archeio/app/handlers.go
@@ -23,7 +23,7 @@ import (
 
 	"k8s.io/klog/v2"
 
-	"sigs.k8s.io/oci-proxy/pkg/net/cidrs/aws"
+	"k8s.io/registry.k8s.io/pkg/net/cidrs/aws"
 )
 
 type RegistryConfig struct {

--- a/cmd/archeio/main.go
+++ b/cmd/archeio/main.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/oci-proxy/cmd/archeio/app"
+	"k8s.io/registry.k8s.io/cmd/archeio/app"
 )
 
 func main() {

--- a/cmd/archeio/main_test.go
+++ b/cmd/archeio/main_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"sigs.k8s.io/oci-proxy/internal/integration"
+	"k8s.io/registry.k8s.io/internal/integration"
 )
 
 // TestIntegrationMain tests the entire, built binary with an integration

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module sigs.k8s.io/oci-proxy
+module k8s.io/registry.k8s.io
 
 go 1.18
 

--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -33,7 +33,7 @@ cd "${REPO_ROOT}"
 go_test_opts=(
   "-coverprofile=${REPO_ROOT}/bin/${MODE}.cov"
   '-covermode' 'count'
-  '-coverpkg' 'sigs.k8s.io/oci-proxy/...'
+  '-coverpkg' 'k8s.io/registry.k8s.io/...'
 )
 if [[ "${MODE}" = 'unit' ]]; then
   go_test_opts+=('-tags=nointegration')

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,4 +1,4 @@
-module sigs.k8s.io/oci-proxy/hack/tools
+module k8s.io/registry.k8s.io/hack/tools
 
 go 1.13
 

--- a/pkg/net/cidrs/aws/mapper.go
+++ b/pkg/net/cidrs/aws/mapper.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package aws
 
-import "sigs.k8s.io/oci-proxy/pkg/net/cidrs"
+import "k8s.io/registry.k8s.io/pkg/net/cidrs"
 
 // NewAWSRegionMapper returns a new cidrs.IPMapper[string] mapping from
 // IP to AWS regions

--- a/pkg/net/cidrs/aws/mapper_test.go
+++ b/pkg/net/cidrs/aws/mapper_test.go
@@ -20,7 +20,7 @@ import (
 	"net/netip"
 	"testing"
 
-	"sigs.k8s.io/oci-proxy/pkg/net/cidrs"
+	"k8s.io/registry.k8s.io/pkg/net/cidrs"
 )
 
 type testCase struct {


### PR DESCRIPTION
reflecting repo move from kubernetes-sigs/oci-proxy to kubernetes/registry.k8s.io