### PR TITLE
Add more regions for sandbox environments

### DIFF
--- a/hack/make-rules/deploy.sh
+++ b/hack/make-rules/deploy.sh
@@ -28,17 +28,24 @@ REGIONS=(
     asia-east1
     asia-northeast1
     asia-northeast2
+    asia-south1
+    australia-southeast1
     europe-north1
     europe-southwest1
     europe-west1
+    europe-west2
+    europe-west4
     europe-west8
     europe-west9
+    southamerica-west1
     us-central1
     us-east1
     us-east4
     us-east5
     us-south1
+    us-south2
     us-west1
+    us-west2
 )
 
 for REGION in "${REGIONS[@]}"; do


### PR DESCRIPTION
Follow-up of:
  - https://github.com/kubernetes/k8s.io/pull/4258

Ensure same Cloud Run locations in production are the same in the sandbox environment.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>