### PR TITLE
set container conurrency and GOMAXPROCS

### DIFF
--- a/hack/make-rules/deploy.sh
+++ b/hack/make-rules/deploy.sh
@@ -53,6 +53,9 @@ for REGION in "${REGIONS[@]}"; do
         run services update "${SERVICE_BASENAME}-${REGION}" \
         --image "${IMAGE_REPO}:${TAG}" \
         --region "${REGION}" \
+        --concurrency 1000 \
+        `# NOTE: should match number of cores configured` \
+        --update-env-vars GOMAXPROCS=1 \
         `# TODO: if we use this to deploy prod, we need to handle this differently` \
         --args=-v=3
 done

--- a/hack/make-rules/deploy.sh
+++ b/hack/make-rules/deploy.sh
@@ -54,6 +54,7 @@ for REGION in "${REGIONS[@]}"; do
         --image "${IMAGE_REPO}:${TAG}" \
         --region "${REGION}" \
         --concurrency 1000 \
+        --max-instances 10 \
         `# NOTE: should match number of cores configured` \
         --update-env-vars GOMAXPROCS=1 \
         `# TODO: if we use this to deploy prod, we need to handle this differently` \


### PR DESCRIPTION
@ameukam and I have been load testing and tuning in a staging region, in particular we should roll these options out widely:

- GOMAXPROCS to match the cores set in cloud run, to inform the go scheduler (which is not aware of containers let alone dynamic throttling, during request serving available CPU should match that configured and GOMAXPROCS should be set to match this)
- container concurrency up to 1000 (max) from 10 (this is how many requests one container instance will be allowed to handle concurrently, autoscaling more instances handles more)