### PR TITLE
fix deploy parameter script

### DIFF
--- a/hack/make-rules/deploy.sh
+++ b/hack/make-rules/deploy.sh
@@ -55,9 +55,7 @@ for REGION in "${REGIONS[@]}"; do
         --concurrency 1000 \
         --max-instances 10 \
         `# NOTE: should match number of cores configured` \
-        --update-env-vars GOMAXPROCS=1 \
-        `# Use artifact registry repositories`
-        UPSTREAM_REGISTRY_PATH="k8s-artifacts-prod/images" UPSTREAM_REGISTRY_ENDPOINT="https://${REGION}-docker.pkg.dev" \
+        --update-env-vars GOMAXPROCS=1,UPSTREAM_REGISTRY_PATH=k8s-artifacts-prod/images,"UPSTREAM_REGISTRY_ENDPOINT=https://$REGION-docker.pkg.dev" \
         `# TODO: if we use this to deploy prod, we need to handle this differently` \
         --args=-v=3
 done


### PR DESCRIPTION
Follow-up of https://github.com/kubernetes/registry.k8s.io/pull/112.

The `--update-env-vars` subcommand supports only a list of key-value pairs.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>