### PR TITLE
update default URLs

### DIFF
--- a/cmd/archeio/main.go
+++ b/cmd/archeio/main.go
@@ -42,8 +42,8 @@ func main() {
 
 	// make it possible to override k8s.gcr.io without rebuilding in the future
 	registryConfig := app.RegistryConfig{
-		UpstreamRegistryEndpoint: getEnv("UPSTREAM_REGISTRY_ENDPOINT", "https://k8s.gcr.io"),
-		UpstreamRegistryPath:     getEnv("UPSTREAM_REGISTRY_PATH", ""),
+		UpstreamRegistryEndpoint: getEnv("UPSTREAM_REGISTRY_ENDPOINT", "https://us-central1-docker.pkg.dev"),
+		UpstreamRegistryPath:     getEnv("UPSTREAM_REGISTRY_PATH", "k8s-artifacts-prod/images"),
 		InfoURL:                  "https://github.com/kubernetes/registry.k8s.io",
 		PrivacyURL:               "https://www.linuxfoundation.org/privacy-policy/",
 	}

--- a/cmd/archeio/main.go
+++ b/cmd/archeio/main.go
@@ -44,7 +44,7 @@ func main() {
 	registryConfig := app.RegistryConfig{
 		UpstreamRegistryEndpoint: getEnv("UPSTREAM_REGISTRY_ENDPOINT", "https://k8s.gcr.io"),
 		UpstreamRegistryPath:     getEnv("UPSTREAM_REGISTRY_PATH", ""),
-		InfoURL:                  "https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)",
+		InfoURL:                  "https://github.com/kubernetes/registry.k8s.io",
 		PrivacyURL:               "https://www.linuxfoundation.org/privacy-policy/",
 	}
 


### PR DESCRIPTION
- Update info URL to point here. 
  - I've done a docs sweep and we have current docs here that also link out to the other docs. More importantly we'd like people to file issues here if they're filing one, so those of us with access to fix the infra see them immediately with high signal : noise ratio (IE I watch this repo and unlike k8s.io repo the issues are very specific to this project)
- Update default registry endpoint config to point to artifact registry
  - We can't keep using k8s.gcr.io (we are not in production anyhow) because soon it will redirect to us ... so use one of the AR regions. I chose us-central1 because prow.k8s.io is primarily there.