### PR TITLE
map to nearest AWS regions as previously proposed

### DIFF
--- a/cmd/archeio/app/buckets.go
+++ b/cmd/archeio/app/buckets.go
@@ -36,28 +36,28 @@ func awsRegionToS3URL(region string) string {
 	// shifting other regions that do not have their own bucket
 
 	// US East (N. Virginia)
-	case "us-east-1", "sa-east-1":
+	case "us-east-1", "sa-east-1", "us-gov-east-1", "GLOBAL":
 		return "https://prod-registry-k8s-io-us-east-1.s3.dualstack.us-east-1.amazonaws.com"
 	// US East (Ohio)
 	case "us-east-2", "ca-central-1":
 		return "https://prod-registry-k8s-io-us-east-2.s3.dualstack.us-east-2.amazonaws.com"
 	// US West (N. California)
-	case "us-west-1":
+	case "us-west-1", "us-gov-west-1":
 		return "https://prod-registry-k8s-io-us-west-1.s3.dualstack.us-west-1.amazonaws.com"
 	// US West (Oregon)
-	case "us-west-2":
+	case "us-west-2", "ca-west-1":
 		return "https://prod-registry-k8s-io-us-west-2.s3.dualstack.us-west-2.amazonaws.com"
 	// Asia Pacific (Mumbai)
-	case "ap-south-1", "me-south-1":
+	case "ap-south-1", "ap-south-2", "me-south-1", "me-central-1":
 		return "https://prod-registry-k8s-io-ap-south-1.s3.dualstack.ap-south-1.amazonaws.com"
 	// Asia Pacific (Tokyo)
 	case "ap-northeast-1", "ap-northeast-2", "ap-northeast-3":
 		return "https://prod-registry-k8s-io-ap-northeast-1.s3.dualstack.ap-northeast-1.amazonaws.com"
 	// Asia Pacific (Singapore)
-	case "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ap-east-1":
+	case "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ap-southeast-4", "ap-southeast-6", "ap-east-1", "cn-northwest-1", "cn-north-1":
 		return "https://prod-registry-k8s-io-ap-southeast-1.s3.dualstack.ap-southeast-1.amazonaws.com"
 	// Europe (Frankfurt)
-	case "eu-central-1", "eu-south-1":
+	case "eu-central-1", "eu-central-2", "eu-south-1", "eu-south-2", "il-central-1":
 		return "https://prod-registry-k8s-io-eu-central-1.s3.dualstack.eu-central-1.amazonaws.com"
 	// Europe (Ireland)
 	case "eu-west-1", "af-south-1":

--- a/cmd/archeio/app/buckets.go
+++ b/cmd/archeio/app/buckets.go
@@ -17,7 +17,6 @@ limitations under the License.
 package app
 
 import (
-	"fmt"
 	"net/http"
 	"sync"
 
@@ -29,11 +28,53 @@ import (
 // blobs in the buckets should be stored at /containers/images/sha256:$hash
 func awsRegionToS3URL(region string) string {
 	switch region {
-	case "us-west-1", "us-west-2", "us-east-1", "us-east-2", "eu-central-1", "eu-west-1", "ap-southeast-1", "ap-northeast-1", "ap-south-1":
-		return fmt.Sprintf("https://prod-registry-k8s-io-%v.s3.dualstack.%v.amazonaws.com", region, region)
-	default:
-		// default to us-east-2 for stability purposes
+	// each of these has the region in which we have a bucket listed first
+	// and then additional regions we're mapping to that bucket
+	// based roughly on physical adjacency (and therefore _presumed_ latency)
+	//
+	// if you add a bucket, add a case for the region it is in, and consider
+	// shifting other regions that do not have their own bucket
+
+	// US East (N. Virginia)
+	case "us-east-1", "sa-east-1":
+		return "https://prod-registry-k8s-io-us-east-1.s3.dualstack.us-east-1.amazonaws.com"
+	// US East (Ohio)
+	case "us-east-2", "ca-central-1":
 		return "https://prod-registry-k8s-io-us-east-2.s3.dualstack.us-east-2.amazonaws.com"
+	// US West (N. California)
+	case "us-west-1":
+		return "https://prod-registry-k8s-io-us-west-1.s3.dualstack.us-west-1.amazonaws.com"
+	// US West (Oregon)
+	case "us-west-2":
+		return "https://prod-registry-k8s-io-us-west-2.s3.dualstack.us-west-2.amazonaws.com"
+	// Asia Pacific (Mumbai)
+	case "ap-south-1", "me-south-1":
+		return "https://prod-registry-k8s-io-ap-south-1.s3.dualstack.ap-south-1.amazonaws.com"
+	// Asia Pacific (Tokyo)
+	case "ap-northeast-1", "ap-northeast-2", "ap-northeast-3":
+		return "https://prod-registry-k8s-io-ap-northeast-1.s3.dualstack.ap-northeast-1.amazonaws.com"
+	// Asia Pacific (Singapore)
+	case "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ap-east-1":
+		return "https://prod-registry-k8s-io-ap-southeast-1.s3.dualstack.ap-southeast-1.amazonaws.com"
+	// Europe (Frankfurt)
+	case "eu-central-1", "eu-south-1":
+		return "https://prod-registry-k8s-io-eu-central-1.s3.dualstack.eu-central-1.amazonaws.com"
+	// Europe (Ireland)
+	case "eu-west-1", "af-south-1":
+		return "https://prod-registry-k8s-io-eu-west-1.s3.dualstack.eu-west-1.amazonaws.com"
+	// Europe (London)
+	case "eu-west-2", "eu-west-3", "eu-north-1":
+		return "https://prod-registry-k8s-io-eu-west-2.s3.dualstack.eu-west-2.amazonaws.com"
+	default:
+		// TestRegionToAWSRegionToS3URL checks we return a non-empty result for all regions
+		// that this app knows about
+		//
+		// we will not attempt to route to a region we do now know about
+		//
+		// if we see empty string returned, then we've failed to account for all regions
+		//
+		// we want to precompute the mapping for all regions
+		return ""
 	}
 }
 

--- a/cmd/archeio/app/buckets_test.go
+++ b/cmd/archeio/app/buckets_test.go
@@ -26,9 +26,13 @@ func TestRegionToAWSRegionToS3URL(t *testing.T) {
 	// ensure all known regions return a configured bucket
 	regions := aws.Regions()
 	for region := range regions {
-		bucket := awsRegionToS3URL(region)
-		if bucket == "" {
-			t.Fatalf("received empty string for known region %q bucket", region)
+		url := awsRegionToS3URL(region)
+		if url == "" {
+			t.Fatalf("received empty string for known region %q url", region)
 		}
+	}
+	// ensure bogus region would return "" so we know above test is valid
+	if url := awsRegionToS3URL("nonsensical-region"); url != "" {
+		t.Fatalf("received non-empty URL string for made up region \"nonsensical-region\": %q", url)
 	}
 }

--- a/cmd/archeio/app/handlers_test.go
+++ b/cmd/archeio/app/handlers_test.go
@@ -160,6 +160,7 @@ func TestMakeV2Handler(t *testing.T) {
 			"https://prod-registry-k8s-io-us-east-2.s3.dualstack.us-east-2.amazonaws.com/containers/images/sha256%3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e":           true,
 			"https://prod-registry-k8s-io-us-west-1.s3.dualstack.us-west-1.amazonaws.com/containers/images/sha256%3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e":           true,
 			"https://prod-registry-k8s-io-us-west-2.s3.dualstack.us-west-2.amazonaws.com/containers/images/sha256%3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e":           true,
+			"https://prod-registry-k8s-io-eu-west-2.s3.dualstack.eu-west-2.amazonaws.com/containers/images/sha256%3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e":           true,
 		},
 	}
 	handler := makeV2Handler(registryConfig, &blobs)
@@ -194,7 +195,7 @@ func TestMakeV2Handler(t *testing.T) {
 				return r
 			}(),
 			ExpectedStatus: http.StatusTemporaryRedirect,
-			ExpectedURL:    "https://prod-registry-k8s-io-us-east-2.s3.dualstack.us-east-2.amazonaws.com/containers/images/sha256%3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e",
+			ExpectedURL:    "https://prod-registry-k8s-io-eu-west-2.s3.dualstack.eu-west-2.amazonaws.com/containers/images/sha256%3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e",
 		},
 		{
 			Name:           "AWS IP, /v2/pause/manifests/latest",


### PR DESCRIPTION
This ensure we're not routing traffic from Asia to the US ...

The mapping is from https://github.com/kubernetes/registry.k8s.io/issues/72#issue-1225709110

Initial commit _should fail_ CI, because that mapping is actually missing regions. Will follow up with adding those regions.