### PR TITLE
export getClientip as pkg/clientip.Get

### DIFF
--- a/cmd/archeio/app/handlers.go
+++ b/cmd/archeio/app/handlers.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/klog/v2"
 
+	"k8s.io/registry.k8s.io/pkg/clientip"
 	"k8s.io/registry.k8s.io/pkg/net/cidrs/aws"
 )
 
@@ -111,7 +112,7 @@ func makeV2Handler(rc RegistryConfig, blobs blobChecker) func(w http.ResponseWri
 		hash := matches[1]
 
 		// for blob requests, check the client IP and determine the best backend
-		clientIP, err := getClientIP(r)
+		clientIP, err := clientip.Get(r)
 		if err != nil {
 			// this should not happen
 			klog.ErrorS(err, "failed to get client IP")

--- a/pkg/clientip/clientip.go
+++ b/pkg/clientip/clientip.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package app
+package clientip
 
 import (
 	"fmt"
@@ -24,14 +24,14 @@ import (
 	"strings"
 )
 
-// getClientIP gets the client IP for an http.Request
+// Get gets the client IP for an http.Request
 //
 // NOTE: currently only two scenarios are supported:
 // 1. no loadbalancer, local testing
-// 2. behind Google Cloud LoadBalancer
+// 2. behind Google Cloud LoadBalancer (as in cloudrun)
 //
 // At this time we have no need to complicate it further
-func getClientIP(r *http.Request) (netip.Addr, error) {
+func Get(r *http.Request) (netip.Addr, error) {
 	// Upstream docs:
 	// https://cloud.google.com/load-balancing/docs/https#x-forwarded-for_header
 	//

--- a/pkg/clientip/clientip_test.go
+++ b/pkg/clientip/clientip_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package app
+package clientip
 
 import (
 	"net/http"
@@ -22,7 +22,7 @@ import (
 	"testing"
 )
 
-func TestGetClientIP(t *testing.T) {
+func TestGet(t *testing.T) {
 	testCases := []struct {
 		Name        string
 		Request     http.Request
@@ -88,7 +88,7 @@ func TestGetClientIP(t *testing.T) {
 		tc := testCases[i]
 		t.Run(tc.Name, func(t *testing.T) {
 			//t.Parallel()
-			ip, err := getClientIP(&tc.Request)
+			ip, err := Get(&tc.Request)
 			if err != nil {
 				if !tc.ExpectError {
 					t.Fatalf("unexpted error: %v", err)


### PR DESCRIPTION
for reuse by porche.

I almost put this in a package called `cloudrun`, because it's hard to fully generalize this method without making it much more complex and inefficient and it's unclear that we should be prioritizing arbitrary network topologies, versus just implementing specific ones as needed.

currently we assume this is either local HTTP testing in-memory, or else serving in cloud-run, where we can make assumptions about header availability and content.

originally I just didn't export this, to revisit later, but we'll have the same issue in porche