### PR TITLE
clientip: Add tests for IPv6

### DIFF
--- a/pkg/clientip/clientip.go
+++ b/pkg/clientip/clientip.go
@@ -30,7 +30,11 @@ import (
 // 1. no loadbalancer, local testing
 // 2. behind Google Cloud LoadBalancer (as in cloudrun)
 //
-// At this time we have no need to complicate it further
+// Note that in particular we do not support hitting the CloudRun endpoint
+// directly (though we could easily do so here). Cloud Armor is on the GCLB,
+// so directly accessing the CloudRun endpoint would bypass that.
+//
+// At this time we have no need to complicate it further.
 func Get(r *http.Request) (netip.Addr, error) {
 	// Upstream docs:
 	// https://cloud.google.com/load-balancing/docs/https#x-forwarded-for_header


### PR DESCRIPTION
I thought this was not working correctly because of IPv6, it turned
out it was not working because I was trying to hit the CloudRun
endpoint directly.  Added some test coverage to prove that it works
and document this.
