### PR TITLE
Handle unknown AWS regions explicitly

### DIFF
--- a/cmd/archeio/app/buckets.go
+++ b/cmd/archeio/app/buckets.go
@@ -26,7 +26,9 @@ import (
 // awsRegionToS3URL returns the base S3 bucket URL for an OCI layer blob given the AWS region
 //
 // blobs in the buckets should be stored at /containers/images/sha256:$hash
-func awsRegionToS3URL(region string) string {
+//
+// If the region is not known, returns false.
+func awsRegionToS3URL(region string) (string, bool) {
 	switch region {
 	// each of these has the region in which we have a bucket listed first
 	// and then additional regions we're mapping to that bucket
@@ -37,44 +39,36 @@ func awsRegionToS3URL(region string) string {
 
 	// US East (N. Virginia)
 	case "us-east-1", "sa-east-1", "us-gov-east-1", "GLOBAL":
-		return "https://prod-registry-k8s-io-us-east-1.s3.dualstack.us-east-1.amazonaws.com"
+		return "https://prod-registry-k8s-io-us-east-1.s3.dualstack.us-east-1.amazonaws.com", true
 	// US East (Ohio)
 	case "us-east-2", "ca-central-1":
-		return "https://prod-registry-k8s-io-us-east-2.s3.dualstack.us-east-2.amazonaws.com"
+		return "https://prod-registry-k8s-io-us-east-2.s3.dualstack.us-east-2.amazonaws.com", true
 	// US West (N. California)
 	case "us-west-1", "us-gov-west-1":
-		return "https://prod-registry-k8s-io-us-west-1.s3.dualstack.us-west-1.amazonaws.com"
+		return "https://prod-registry-k8s-io-us-west-1.s3.dualstack.us-west-1.amazonaws.com", true
 	// US West (Oregon)
 	case "us-west-2", "ca-west-1":
-		return "https://prod-registry-k8s-io-us-west-2.s3.dualstack.us-west-2.amazonaws.com"
+		return "https://prod-registry-k8s-io-us-west-2.s3.dualstack.us-west-2.amazonaws.com", true
 	// Asia Pacific (Mumbai)
 	case "ap-south-1", "ap-south-2", "me-south-1", "me-central-1":
-		return "https://prod-registry-k8s-io-ap-south-1.s3.dualstack.ap-south-1.amazonaws.com"
+		return "https://prod-registry-k8s-io-ap-south-1.s3.dualstack.ap-south-1.amazonaws.com", true
 	// Asia Pacific (Tokyo)
 	case "ap-northeast-1", "ap-northeast-2", "ap-northeast-3":
-		return "https://prod-registry-k8s-io-ap-northeast-1.s3.dualstack.ap-northeast-1.amazonaws.com"
+		return "https://prod-registry-k8s-io-ap-northeast-1.s3.dualstack.ap-northeast-1.amazonaws.com", true
 	// Asia Pacific (Singapore)
 	case "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ap-southeast-4", "ap-southeast-6", "ap-east-1", "cn-northwest-1", "cn-north-1":
-		return "https://prod-registry-k8s-io-ap-southeast-1.s3.dualstack.ap-southeast-1.amazonaws.com"
+		return "https://prod-registry-k8s-io-ap-southeast-1.s3.dualstack.ap-southeast-1.amazonaws.com", true
 	// Europe (Frankfurt)
 	case "eu-central-1", "eu-central-2", "eu-south-1", "eu-south-2", "il-central-1":
-		return "https://prod-registry-k8s-io-eu-central-1.s3.dualstack.eu-central-1.amazonaws.com"
+		return "https://prod-registry-k8s-io-eu-central-1.s3.dualstack.eu-central-1.amazonaws.com", true
 	// Europe (Ireland)
 	case "eu-west-1", "af-south-1":
-		return "https://prod-registry-k8s-io-eu-west-1.s3.dualstack.eu-west-1.amazonaws.com"
+		return "https://prod-registry-k8s-io-eu-west-1.s3.dualstack.eu-west-1.amazonaws.com", true
 	// Europe (London)
 	case "eu-west-2", "eu-west-3", "eu-north-1":
-		return "https://prod-registry-k8s-io-eu-west-2.s3.dualstack.eu-west-2.amazonaws.com"
+		return "https://prod-registry-k8s-io-eu-west-2.s3.dualstack.eu-west-2.amazonaws.com", true
 	default:
-		// TestRegionToAWSRegionToS3URL checks we return a non-empty result for all regions
-		// that this app knows about
-		//
-		// we will not attempt to route to a region we do now know about
-		//
-		// if we see empty string returned, then we've failed to account for all regions
-		//
-		// we want to precompute the mapping for all regions
-		return ""
+		return "", false
 	}
 }
 

--- a/cmd/archeio/app/buckets_integration_test.go
+++ b/cmd/archeio/app/buckets_integration_test.go
@@ -24,7 +24,10 @@ import (
 )
 
 func TestCachedBlobChecker(t *testing.T) {
-	bucket := awsRegionToS3URL("us-east-1")
+	bucket, found := awsRegionToS3URL("us-east-1")
+	if !found {
+		t.Fatalf("awsRegionToS3URL gave unexpected value; got not-found but expected to be found")
+	}
 	blobs := newCachedBlobChecker()
 	testCases := []struct {
 		Name         string

--- a/cmd/archeio/app/buckets_test.go
+++ b/cmd/archeio/app/buckets_test.go
@@ -26,13 +26,13 @@ func TestRegionToAWSRegionToS3URL(t *testing.T) {
 	// ensure all known regions return a configured bucket
 	regions := aws.Regions()
 	for region := range regions {
-		url := awsRegionToS3URL(region)
-		if url == "" {
-			t.Fatalf("received empty string for known region %q url", region)
+		_, found := awsRegionToS3URL(region)
+		if !found {
+			t.Fatalf("could not find s3 mirror for known region %q", region)
 		}
 	}
-	// ensure bogus region would return "" so we know above test is valid
-	if url := awsRegionToS3URL("nonsensical-region"); url != "" {
-		t.Fatalf("received non-empty URL string for made up region \"nonsensical-region\": %q", url)
+	// ensure bogus region returns false
+	if url, found := awsRegionToS3URL("nonsensical-region"); found {
+		t.Fatalf("received non-empty mirror for made up region \"nonsensical-region\": %q", url)
 	}
 }


### PR DESCRIPTION
We were joining to an empty string, which is likely unintended.
