### PR TITLE
Add readme link to doc for publishing images

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The community deployment configs are documented at in the k8s.io repo with
 the rest of the community infra deployments:
 https://github.com/kubernetes/k8s.io/tree/main/registry.k8s.io
 
+For publishing to registry.k8s.io, refer to the docs at https://git.k8s.io/k8s.io/k8s.gcr.io#managing-kubernetes-container-registries
+
 ## Stability
 
 registry.k8s.io is GA and we ask that all users migrate from k8s.gcr.io as


### PR DESCRIPTION
I couldn't find these docs at all, someone who publishes images kindly linked me to them (/ht @dgrisonnet).

This repo was the first place I checked for documentation, since I thought registry.k8s.io was replacing k8s.gcr.io. https://registry.k8s.io redirected to this repo which only discusses the proxy implementation and not the registry itself.