### PR TITLE
reject requests for /v2/_catalog

### DIFF
--- a/cmd/archeio/app/handlers.go
+++ b/cmd/archeio/app/handlers.go
@@ -99,6 +99,12 @@ func makeV2Handler(rc RegistryConfig, blobs blobChecker) func(w http.ResponseWri
 			w.WriteHeader(http.StatusOK)
 			return
 		}
+		// we don't support the non-standard _catalog API
+		// https://github.com/kubernetes/registry.k8s.io/issues/162
+		if rPath == "/v2/_catalog" {
+			http.Error(w, "_catalog is not supported", http.StatusNotFound)
+			return
+		}
 
 		// check if blob request
 		matches := reBlob.FindStringSubmatch(rPath)

--- a/cmd/archeio/app/handlers_test.go
+++ b/cmd/archeio/app/handlers_test.go
@@ -186,6 +186,15 @@ func TestMakeV2Handler(t *testing.T) {
 			ExpectedStatus: http.StatusBadRequest,
 		},
 		{
+			Name: "/v2/_catalog",
+			Request: func() *http.Request {
+				r := httptest.NewRequest("GET", "http://localhost:8080/v2/_catalog", nil)
+				r.RemoteAddr = "35.180.1.1:888"
+				return r
+			}(),
+			ExpectedStatus: http.StatusNotFound,
+		},
+		{
 			Name: "AWS IP, /v2/pause/blobs/sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e",
 			Request: func() *http.Request {
 				r := httptest.NewRequest("GET", "http://localhost:8080/v2/pause/blobs/sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e", nil)


### PR DESCRIPTION
cc @jonjohnsonjr

pros:
- _catalog is non-portable, not supporting it leaves us more flexibility in what registry we depend on
- _catalog is scoped to a registry host, not a repository

cons:
- _catalog is useful, implementing it would be more helpful (but also then we need to continue to support it...)

I think blocking the broken call (we redirect to a path prefixed _catalog which won't work anywhere) is better than leaving a broken one. We can continue discussing potentially implementing in the meantime.