### PR TITLE
rate limit all AR API calls

### DIFF
--- a/cmd/geranos/ratelimitroundtrip.go
+++ b/cmd/geranos/ratelimitroundtrip.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"net/http"
+
+	"golang.org/x/time/rate"
+)
+
+// RateLimitRoundTripper wraps an http.RoundTripper with rate limiting
+type RateLimitRoundTripper struct {
+	rateLimiter  *rate.Limiter
+	roundTripper http.RoundTripper
+}
+
+var _ http.RoundTripper = &RateLimitRoundTripper{}
+
+func NewRateLimitRoundTripper(limit rate.Limit, burst int) *RateLimitRoundTripper {
+	return &RateLimitRoundTripper{
+		rateLimiter:  rate.NewLimiter(limit, burst),
+		roundTripper: http.DefaultTransport,
+	}
+}
+
+func (rt *RateLimitRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	err := rt.rateLimiter.Wait(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return rt.roundTripper.RoundTrip(r)
+}

--- a/cmd/geranos/s3uploader.go
+++ b/cmd/geranos/s3uploader.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/hex"
 
@@ -79,7 +78,6 @@ func (s *s3Uploader) CopyToS3(bucket string, layer v1.Layer) error {
 			return nil
 		}
 	}
-	_ = gcpRateLimiter.Wait(context.Background())
 	r, err := layer.Compressed()
 	if err != nil {
 		return err

--- a/cmd/geranos/schemav1.go
+++ b/cmd/geranos/schemav1.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -27,7 +28,7 @@ import (
 )
 
 // layersForV1 gets the layers for a v1 schema image
-func layersForV1(ref name.Reference, desc *remote.Descriptor) ([]v1.Layer, error) {
+func layersForV1(transport http.RoundTripper, ref name.Reference, desc *remote.Descriptor) ([]v1.Layer, error) {
 	m := &schema1{}
 	if err := json.NewDecoder(bytes.NewReader(desc.Manifest)).Decode(m); err != nil {
 		return nil, err
@@ -38,7 +39,7 @@ func layersForV1(ref name.Reference, desc *remote.Descriptor) ([]v1.Layer, error
 		if err != nil {
 			return nil, err
 		}
-		layer, err := remote.Layer(layerDigest)
+		layer, err := remote.Layer(layerDigest, remote.WithTransport(transport))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
more complete and invasive version of #165 

worth noting: 

> In most cases, a single HTTP request or API call counts as a single request. However, some operations count as multiple requests. For example, a batch request like ImportAptArtifacts might charge quota for each item in the batch. A Docker pull or push usually makes multiple HTTP requests, so quota is charged for each request.

https://cloud.google.com/artifact-registry/quotas