### PR TITLE
add test coverage for handlers

### DIFF
--- a/cmd/archeio/app/handlers_test.go
+++ b/cmd/archeio/app/handlers_test.go
@@ -97,6 +97,16 @@ func TestMakeHandler(t *testing.T) {
 			ExpectedStatus: http.StatusTemporaryRedirect,
 			ExpectedURL:    "https://us.gcr.io/v2/k8s-artifacts-prod/pause/blobs/sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e",
 		},
+		{
+			Name: "GCP IP, /v2/pause/blobs/sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e",
+			Request: func() *http.Request {
+				r := httptest.NewRequest("GET", "http://localhost:8080/v2/pause/blobs/sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e", nil)
+				r.RemoteAddr = "35.220.26.1:888"
+				return r
+			}(),
+			ExpectedStatus: http.StatusTemporaryRedirect,
+			ExpectedURL:    "https://us.gcr.io/v2/k8s-artifacts-prod/pause/blobs/sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e",
+		},
 	}
 	for i := range testCases {
 		tc := testCases[i]


### PR DESCRIPTION
Follow up https://github.com/kubernetes/registry.k8s.io/pull/164#issuecomment-1461350616 #147 

After this change:
> ok  	k8s.io/registry.k8s.io/cmd/archeio/app	2.440s	coverage: 100.0% of statements


`cmd/geranos` also has ~no test coverage, but unlike `cmd/archeio` it's not serving end-user production traffic and nearly all of the code is interacting with API clients for complex external services so .... 

bugs in archeio are *much* more pressing, and I hope we can continue to main highly robust test coverage there.