### PR TITLE
increase geranos registry rate limit

### DIFF
--- a/cmd/geranos/main.go
+++ b/cmd/geranos/main.go
@@ -45,9 +45,9 @@ func Run(_ []string) error {
 	// TODO: make configurable later
 	const s3Bucket = "prod-registry-k8s-io-us-east-2"
 
-	// 60*60s = 3600 RPM, which should be well below our current 5000 RPM
-	// limit, even with the host node making other registry API calls
-	registryRateLimit := NewRateLimitRoundTripper(60, 1)
+	// 80*60s = 4800 RPM, below our current 5000 RPM per-user limit on the registry
+	// Even with the host node making other registry API calls
+	registryRateLimit := NewRateLimitRoundTripper(80, 1)
 
 	repo, err := name.NewRepository(sourceRegistry)
 	if err != nil {


### PR DESCRIPTION
ref #166 #153 

This is working fine now, but a bit slower than desirable.

I'm going to work on other improvements, but in the meantime we might as well push closer to the rate limit and reduce the sync time hit (~13m => ~1h30m).