### PR TITLE
clarify archeio docs

### DIFF
--- a/cmd/archeio/README.md
+++ b/cmd/archeio/README.md
@@ -7,14 +7,6 @@ OCI artifact ("docker image") hosting.
 
 Current design details will be detailed here as they mature.
 
-The original design doc is shared with members of
-[dev@kubernetes.io](https://groups.google.com/a/kubernetes.io/g/dev), 
-anyone can join this list and gain access to read
-[the document](https://docs.google.com/document/d/1yNQ7DaDE5LbDJf9ku82YtlKZK0tcg5Wpk9L72-x2S2k/). 
-It is not accessible to accounts that are not members of the Kubernetes mailinglist
-due to organization constraints and joining the list is the most reliable way to gain
-access. See https://git.k8s.io/community/community-membership.md
-
 For more current details see also: https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)
 
 **NOTE**: The code in this binary is **not** intended to be fully reusable,
@@ -22,6 +14,8 @@ it is the most efficient and expedient implementation of
 Kubernetes SIG K8s-Infra's needs. However, some of the packages under
 [`pkg/`](./../../pkg/) may be useful if you have a similar problem,
 and they should be pretty generalized and re-usable.
+
+Please also see the main repo README and in particular [the "stability" note](./../../#stability).
 
 -----
 
@@ -31,20 +25,60 @@ For a rough TLDR of the current design:
 - Mirrors *of content* blobs are hosted in S3 buckets in AWS
 - AWS clients are detected by client IP address and redirect to a local S3 bucket copy
 *only* when requesting content blobs, *not* manifests, manifest lists, tags etc.
-- All other requests are redirected to the original upstream registry
+- GCP clients and other requests are rerouted to the regional upstream source Artifact Registries
+
+This allows us to offload substantial bandwidth securely, while not having to fully
+implement a registry from scratch and maintaining the project's existing security
+controls around the GCP source registries (implemented elsewhere in the Kubernetes project).
+We only re-route some content-addressed storage requests to additional hosts.
+
+Clients do still need to either pull by digest (`registry.k8s.io/foo@sha256:...`),
+verify sigstore signatures, or else trust that the redirector instance is secure.
+
+We maintain relatively tight control over the production redirector instance and
+the source registries. Very few contributors have access to this infrastructure.
+
+We have a development instance at https://registry-sandbox.k8s.io which is
+*not* supported for any usage outside of the development of this project and 
+may or may not be working at any given time. 
+Changes will be deployed there before we deploy to production, and be exercised
+by a subset of Kubernetes' own CI.
+
 
 For more detail see:
-- [docs/request-handling.md](./docs/request-handling.md)
-- [docs/testing.md](./docs/testing.md)
+- How requests are handled: [docs/request-handling.md](./docs/request-handling.md)
+- How we test registry.k8s.io changes: [docs/testing.md](./docs/testing.md)
+- For IP matching info for both AWS and GCP ranges: [`pkg/net/cloudcidrs`](./../../pkg/net/cloudcidrs)
 
-In addition, in order to get the registry.k8s.io domain in place, initially this
-binary is *only* serving the trivial redirect to the existing registry 
-(https://k8s.gcr.io), so we can safely move users / clients to the new domain
-that will eventually serve the more complex version.
+----
 
-Development is at https://registry-sandbox.k8s.io which is *not* supported for
-any usage outside of the development of this project and may or may not be
-working at any given time. Changes will be deployed there before we deploy
-to production, and be exercised by a subset of Kubernetes' own CI.
+Historical Context:
 
-For IP matching info for both AWS and GCP ranges, see [`pkg/net/cloudcidrs`](./../../pkg/net/cloudcidrs)
+**You must join one of the open community mailinglists below to access the original design doc.**
+
+The original design doc is shared with members of
+[dev@kubernetes.io](https://groups.google.com/a/kubernetes.io/g/dev), 
+anyone can join this list and gain access to read
+[the document](https://docs.google.com/document/d/1yNQ7DaDE5LbDJf9ku82YtlKZK0tcg5Wpk9L72-x2S2k/). 
+It is not accessible to accounts that are not members of the Kubernetes mailinglist
+due to organization constraints and joining the list is the **only** way to gain
+access. See https://git.k8s.io/community/community-membership.md
+
+It is not fully reflective of the current design anyhow, but some may find it
+interesting.
+
+Originally the project primarily needed to take advantage of an offer from Amazon
+to begin paying for AWS user traffic, which was the majority of our traffic and
+cost a lot due to high amounts of egress traffic between GCP<>AWS.
+
+In addition, in order to get the registry.k8s.io domain in place, initially we
+only served a trivial redirect to the existing registry 
+(https://k8s.gcr.io), so we could safely start to move users / clients to the new domain
+that would eventually serve the more complex version.
+
+Since then we've redesigned a bit to make populating content into AWS async and
+not blocked on the image promoter, as well as extending our Geo-routing approach
+to detect and route users on dimensions other than "is a known AWS IP in a known AWS region".
+
+More changes will come in the future, and these implementation details while documented
+**CANNOT** be depended on.

--- a/cmd/archeio/docs/request-handling.md
+++ b/cmd/archeio/docs/request-handling.md
@@ -21,9 +21,11 @@ flowchart TD
 A(Does the request path start with /v2/?) -->|No, it is not a registry API call| B(Is the request for /?)
 B -->|No| D[Is the request for /privacy?]
 D -->|No, it is an unknown path| C[Serve 404 error]
-D -->|Yes| K[Serve redirect to linux foundation privacy policy page]
+D -->|Yes| K[Serve redirect to Linux Foundation privacy policy page]
 B -->|Yes| E[Serve redirect to registry wiki page]
-A -->|Yes, it is a registry API call| F(Is it a blob request?)
+A -->|Yes, it is a registry API call| L(Is it an OCI Distribution Standard API Call?)
+L -->|No, it is a non-standard API call.<br>Currently: `/v2/_catalog`.| M[Serve 404 error]
+L -->|Yes, it is a standard API call| F(Is it a blob request?)
 F -->|No| G[Serve redirect to Source Registry on GCP]
 F -->|Yes, it matches known blob request format| H(Is the client IP known to be from GCP?)
 H -->|Yes| G

--- a/cmd/archeio/docs/request-handling.md
+++ b/cmd/archeio/docs/request-handling.md
@@ -2,15 +2,17 @@
 
 Requests to archeio follows the following flow:
 
-1. If it's a request for `/`: redirect to our wiki page about the project
-1. If it's a request for `/privacy`: redirect to linux foundation privacy policy page
+1. If it's a request for `/`: Redirect to our wiki page about the project
+1. If it's a request for `/privacy`: Redirect to Linux Foundation privacy policy page
 1. If it's not a request for `/` or `/privacy` and does not start with `/v2/`: 404 error
 1. For registry API requests, all of which start with `/v2/`:
-    - If it's a manifest request: redirect to Upstream Registry
-    - If it's from a known GCP IP: redirect to Upstream Registry
-    -  If it's a known AWS IP AND HEAD request for the layer succeeeds in S3: redirect to S3
-    -  If it's a known AWS IP AND HEAD fails: redirect to Upstream Registry
-1. OCI Distribution [Specification](https://github.com/opencontainers/distribution-spec/blob/main/spec.md)
+    - If it's a non-standard API call (`/v2/_catalog`): 404 error
+    - If it's a manifest request: Redirect to Upstream Registry
+    - If it's from a known GCP IP: Redirect to Upstream Registry
+    -  If it's a known AWS IP AND HEAD request for the layer succeeeds in S3: Redirect to S3
+    -  If it's a known AWS IP AND HEAD fails: Redirect to Upstream Registry
+
+See also: OCI Distribution [Specification](https://github.com/opencontainers/distribution-spec/blob/main/spec.md)
 
 Currently the `Upstream Registry` is a region specific Artifact Registry backend.
 


### PR DESCRIPTION

- We should discuss the current design before the original design
- Clarifying that you *must* join the mailinglist to access the original design sketch Google doc, still getting a lot of requests for this doc and this is the only place we currently link it AFAIK. Also clarifying that it's *not* current and the design has evolved, and outlining how that has evolved a bit.
- Adding another pointer to the main readme and particularly the stability section
- Clarifying repeatedly that while we document for transparency, you cannot rely on the implementation details
- Adding a bit more context re: security posture

I need to do a follow-up updating the "request handling" diagrams, we've made some slight changes since the last update.