### PR TITLE
enforce code coverage levels

### DIFF
--- a/cmd/archeio/docs/testing.md
+++ b/cmd/archeio/docs/testing.md
@@ -12,7 +12,7 @@ methods, we also have unit tests covering the HTTP Handlers and full
 
 **This level of coverage must be maintained**, it is imperative that we have robust
 testing in this project that may soon serve all Kubernetes project image downloads.
-TODO: this should be enforced by CI. Currently it is enforced by reviewers.
+We automatically enforce 100% code coverage for archeio sources.
 
 Coverage results are visible by clicking the `pull-oci-proxy-test` context link
 at the bottom of the pull request.

--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -50,17 +50,16 @@ fi
     -- "${go_test_opts[@]}" './...'
 )
 
-# filter out generated files
-sed '/zz_generated/d' "${REPO_ROOT}/bin/${MODE}.cov" > "${REPO_ROOT}/bin/${MODE}-filtered.cov"
-
 # generate cover html
-go tool cover -html="${REPO_ROOT}/bin/${MODE}-filtered.cov" -o "${REPO_ROOT}/bin/${MODE}-filtered.html"
+go tool cover -html="${REPO_ROOT}/bin/${MODE}.cov" -o "${REPO_ROOT}/bin/${MODE}.html"
 
 # if we are in CI, copy to the artifact upload location
 if [[ -n "${ARTIFACTS:-}" ]]; then
   cp "bin/${MODE}-junit.xml" "${ARTIFACTS:?}/junit.xml"
-  cp "${REPO_ROOT}/bin/${MODE}-filtered.cov" "${ARTIFACTS:?}/filtered.cov"
-  cp "${REPO_ROOT}/bin/${MODE}-filtered.html" "${ARTIFACTS:?}/filtered.html"
+  # TODO: currently these names are required in $ARTIFACTS in order to render
+  # in the spyglass view. however we're not filtering anymore
+  cp "${REPO_ROOT}/bin/${MODE}.cov" "${ARTIFACTS:?}/filtered.cov"
+  cp "${REPO_ROOT}/bin/${MODE}.html" "${ARTIFACTS:?}/filtered.html"
 fi
 
 # enforce coverage levels if we're running all tests

--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -39,6 +39,8 @@ if [[ "${MODE}" = 'unit' ]]; then
   go_test_opts+=('-tags=nointegration')
 elif [[ "${MODE}" = 'integration' ]]; then
   go_test_opts+=('-run' '^TestIntegration')
+else
+  MODE="all"
 fi
 
 # run unit tests with coverage enabled and junit output
@@ -59,4 +61,9 @@ if [[ -n "${ARTIFACTS:-}" ]]; then
   cp "bin/${MODE}-junit.xml" "${ARTIFACTS:?}/junit.xml"
   cp "${REPO_ROOT}/bin/${MODE}-filtered.cov" "${ARTIFACTS:?}/filtered.cov"
   cp "${REPO_ROOT}/bin/${MODE}-filtered.html" "${ARTIFACTS:?}/filtered.html"
+fi
+
+# enforce coverage levels if we're running all tests
+if [[ "${MODE}" = 'all' ]]; then
+  (set -x; cd ./hack/tools && go run ./require-coverage)
 fi

--- a/hack/tools/require-coverage/main.go
+++ b/hack/tools/require-coverage/main.go
@@ -59,7 +59,7 @@ var knownFailingFiles = sets.NewString(
 
 func main() {
 	fmt.Println("Checking coverage ...")
-	profiles, err := cover.ParseProfiles("./../../bin/all-filtered.cov")
+	profiles, err := cover.ParseProfiles("./../../bin/all.cov")
 	if err != nil {
 		panic(err)
 	}

--- a/hack/tools/require-coverage/main.go
+++ b/hack/tools/require-coverage/main.go
@@ -39,8 +39,6 @@ var knownFailingFiles = sets.NewString(
 	// this code is used only at development time and integration testing it
 	// is probably excessive
 	"k8s.io/registry.k8s.io/pkg/net/cloudcidrs/internal/ranges2go/main.go",
-	// TODO: this is reasonable to test and has poor coverage currently
-	"k8s.io/registry.k8s.io/pkg/net/cloudcidrs/internal/ranges2go/parse_gcp.go",
 	// TODO: this is reasonable to test but shy of 100% coverage, mostly error handling ...
 	"k8s.io/registry.k8s.io/pkg/net/cloudcidrs/internal/ranges2go/gen.go",
 	// geranos is not easily tested and is not in the blocking path in production

--- a/hack/tools/require-coverage/main.go
+++ b/hack/tools/require-coverage/main.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// A small utility to enforce code coverage levels
+// hack/make-rules/test.sh && (cd ./hack/tools && go run ./require-coverage)
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/tools/cover"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// TODO: instead of fully excluding files, maybe we should have a more
+// flexible pattern of minimum coverage?
+//
+// For now the goal is to require 100% coverage for production serving code.
+// See also: cmd/archeio/docs/testing.md
+//
+// Reviewers should be wary of approving additions to this list.
+var knownFailingFiles = sets.NewString(
+	// this code is used only at development time and integration testing it
+	// is probably excessive
+	"k8s.io/registry.k8s.io/pkg/net/cloudcidrs/internal/ranges2go/main.go",
+	// TODO: this is reasonable to test and has poor coverage currently
+	"k8s.io/registry.k8s.io/pkg/net/cloudcidrs/internal/ranges2go/parse_gcp.go",
+	// TODO: this is reasonable to test but shy of 100% coverage, mostly error handling ...
+	"k8s.io/registry.k8s.io/pkg/net/cloudcidrs/internal/ranges2go/gen.go",
+	// geranos is not easily tested and is not in the blocking path in production
+	// we should still test it better
+	"k8s.io/registry.k8s.io/cmd/geranos/main.go",
+	"k8s.io/registry.k8s.io/cmd/geranos/ratelimitroundtrip.go",
+	"k8s.io/registry.k8s.io/cmd/geranos/s3uploader.go",
+	"k8s.io/registry.k8s.io/cmd/geranos/schemav1.go",
+	"k8s.io/registry.k8s.io/cmd/geranos/walkimages.go",
+	// integration test utilites
+	"k8s.io/registry.k8s.io/internal/integration/paths.go",
+	"k8s.io/registry.k8s.io/internal/integration/bins.go",
+	// TODO: we can cover this
+	"k8s.io/registry.k8s.io/cmd/archeio/main.go",
+)
+
+func main() {
+	fmt.Println("Checking coverage ...")
+	profiles, err := cover.ParseProfiles("./../../bin/all-filtered.cov")
+	if err != nil {
+		panic(err)
+	}
+	failedAny := false
+	for _, profile := range profiles {
+		coverage := coverPercent(profile)
+		file := profile.FileName
+		if coverage < 100.0 {
+			if !knownFailingFiles.Has(file) {
+				failedAny = true
+				fmt.Printf("FAILED: %s %v%%\n", file, coverage)
+			} else {
+				fmt.Printf("IGNORE: %s %v%%\n", file, coverage)
+			}
+		} else {
+			fmt.Printf("PASSED: %s %v%%\n", file, coverage)
+		}
+	}
+	if failedAny {
+		fmt.Println("Failed required coverage levels for one or more go files")
+		os.Exit(-1)
+	} else {
+		fmt.Println("All code coverage either acceptable or ignored")
+	}
+}
+
+func coverPercent(profile *cover.Profile) float64 {
+	totalStatements := 0
+	coveredStatements := 0
+	for _, block := range profile.Blocks {
+		totalStatements += block.NumStmt
+		if block.Count > 0 {
+			coveredStatements += block.NumStmt
+		}
+	}
+	return float64(coveredStatements) / float64(totalStatements) * 100
+}

--- a/hack/tools/require-coverage/main.go
+++ b/hack/tools/require-coverage/main.go
@@ -64,6 +64,7 @@ func main() {
 		panic(err)
 	}
 	failedAny := false
+	needToRemove := []string{}
 	for _, profile := range profiles {
 		coverage := coverPercent(profile)
 		file := profile.FileName
@@ -75,6 +76,9 @@ func main() {
 				fmt.Printf("IGNORE: %s %v%%\n", file, coverage)
 			}
 		} else {
+			if knownFailingFiles.Has(file) {
+				needToRemove = append(needToRemove, file)
+			}
 			fmt.Printf("PASSED: %s %v%%\n", file, coverage)
 		}
 	}
@@ -83,6 +87,13 @@ func main() {
 		os.Exit(-1)
 	} else {
 		fmt.Println("All code coverage either acceptable or ignored")
+	}
+	if len(needToRemove) > 0 {
+		fmt.Println("FAILED: The following files are now passing and must be removed frmo the ignored list:")
+		for _, file := range needToRemove {
+			fmt.Println(file)
+		}
+		os.Exit(-1)
 	}
 }
 

--- a/pkg/net/cloudcidrs/internal/ranges2go/parse_gcp_test.go
+++ b/pkg/net/cloudcidrs/internal/ranges2go/parse_gcp_test.go
@@ -62,7 +62,7 @@ func TestGCPParseIPRangesJSON(t *testing.T) {
 	}
 
 	// parse some bogus data
-	_, err = parseAWSIPRangesJSON([]byte(`{"prefixes": false}`))
+	_, err = parseGCPCloudJSON([]byte(`{"prefixes": false}`))
 	if err == nil {
 		t.Fatal("expected error parsing garbage data but got none")
 	}
@@ -99,6 +99,20 @@ func TestGCPRegionsToPrefixesFromData(t *testing.T) {
 			},
 		}
 		_, err := gcpRegionsToPrefixesFromData(badV6Prefixes)
+		if err == nil {
+			t.Fatal("expected error parsing bogus prefix but got none")
+		}
+	})
+	t.Run("bad no prefixes", func(t *testing.T) {
+		t.Parallel()
+		badNoPrefixes := &GCPCloudJSON{
+			Prefixes: []GCPPrefix{
+				{
+					Scope: "us-east-1",
+				},
+			},
+		}
+		_, err := gcpRegionsToPrefixesFromData(badNoPrefixes)
 		if err == nil {
 			t.Fatal("expected error parsing bogus prefix but got none")
 		}


### PR DESCRIPTION
Quick starting point to fix a long-standing TODO

I couldn't find a great off the shelf tool to simply enforce coverage levels from cover files. There are one or two tools but they tend to require also running the tests.

Go makes it very simple to parse coverage output, so I just wrote a tiny utility to require 100% coverage with some excluded packages. Primarily this ensures production archeio code maintains current coverage levels.