### PR TITLE
docs cleanup and start mirroring guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ image registry.
 For more details on the implementation see [cmd/archeio](./cmd/archeio/README.md)
 
 The community deployment configs are documented at in the k8s.io repo with
-the rest of the community infra deployments:
-https://github.com/kubernetes/k8s.io/tree/main/registry.k8s.io
+the rest of the community infra deployments, but primarily 
+[here][infra-configs].
 
-For publishing to registry.k8s.io, refer to the docs at https://git.k8s.io/k8s.io/k8s.gcr.io#managing-kubernetes-container-registries
+For publishing to registry.k8s.io, refer to [the docs][publishing] at in k8s.io 
+under `registry.k8s.io/`.
 
 ## Stability
 
@@ -79,3 +80,5 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 [owners]: https://git.k8s.io/community/contributors/guide/owners.md
 [Creative Commons 4.0]: https://git.k8s.io/website/LICENSE
 [distribution-spec]: https://github.com/opencontainers/distribution-spec
+[publishing]: https://git.k8s.io/k8s.io/registry.k8s.io#managing-kubernetes-container-registries
+[infra-configs]: https://github.com/kubernetes/k8s.io/tree/main/infra/gcp/terraform

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ https://registry.k8s.io/privacy
 Previously all of Kubernetes' image hosting has been out of gcr.io ("Google Container Registry").
 
 We've incurred significant egress traffic costs from users on other cloud providers
-in particular in doing so, severely limiting our ability to use the infra budget
-for purposes other than hosting end-user downloads.
+in particular in doing so, severely limiting our ability to use the 
+GCP credits from Google for purposes other than hosting end-user downloads.
 
 We're now moving to shift all traffic behind a community controlled domain, so
 we can quickly implement cost-cutting measures like serving the bulk of the traffic

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ are subject to change at _anytime_ as new resources become available or as other
 necessary.**
 
 **If you need to allow-list domains or IPs in your environment, we highly recommend
-mirroring images to a location you control instead.**
+[mirroring] images to a location you control instead.**
 
 The Kubernetes project is currently sending traffic to GCP and AWS
 thanks to their donations but we hope to redirect traffic to more
@@ -36,9 +36,10 @@ Please also note that there is **No SLA** as this is a free, volunteer managed
 service. We will however do our best to respond to issues and the system is
 designed to be reliable and low-maintenance.
 
-See Also: https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga
+See Also:
+- https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga
+- [mirroring]
 
-<!--TODO: link out to a doc with suggestion(s) for mirroring--->
 ## Privacy
 
 This project abides by the Linux Foundation privacy policy, as documented at
@@ -82,3 +83,4 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 [distribution-spec]: https://github.com/opencontainers/distribution-spec
 [publishing]: https://git.k8s.io/k8s.io/registry.k8s.io#managing-kubernetes-container-registries
 [infra-configs]: https://github.com/kubernetes/k8s.io/tree/main/infra/gcp/terraform
+[mirroring]: ./docs/mirroring/README.md

--- a/docs/mirroring/README.md
+++ b/docs/mirroring/README.md
@@ -1,0 +1,63 @@
+# Mirroring
+
+This guide covers mirroring images you use on registry.k8s.io
+to a host under your own control and using those images.
+
+The specific sub-steps will depend on the tools you use, but in general you will need to:
+
+1. Identify the images you need: [Identifying Images To Mirror](#Identifying-Images-To-Mirror)
+2. Mirror those images to your own registry: [Mirroring Images](#Mirroring-Images)
+3. Configure your tools to use the mirrored images: [Using Mirrored Images](#Using-Mirrored-Images)
+
+We have guides here for each of these steps.
+
+## Identifying Images To Mirror
+<!--
+NOTE: Wherever possible do not duplicate external content.
+
+Instead, link to existing official guides and merely provide a lightweight pointer here.
+
+See: https://kubernetes.io/docs/contribute/style/content-guide/#dual-sourced-content
+-->
+
+<!--TODO: Generically identifying registry.k8s.io images in manifests / charts / addons.-->
+
+For containerd see: [containerd.md](./containerd.md)
+For kubeadm see: [kubeadm.md](./kubeadm.md)
+
+
+## Mirroring Images
+<!--
+NOTE: Wherever possible do not duplicate external content.
+
+Instead, link to existing official guides and merely provide a lightweight pointer here.
+
+See: https://kubernetes.io/docs/contribute/style/content-guide/#dual-sourced-content
+-->
+
+This section covers some options for copying images you wish to mirror to your own registry.
+
+### Mirroring With `crane` Or `gcrane`
+
+`crane` is an open-source tool for interacting with remote images and registries.
+`gcrane` is a superset of crane with GCP specific additional features.
+
+For `crane` use `crane copy registry.k8s.io/pause:3.9 my-registry.com/pause:3.9`.
+Docs: https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_copy.md
+
+For `gcrane` see: https://cloud.google.com/container-registry/docs/migrate-external-containers
+
+
+## Using Mirrored Images
+<!--
+NOTE: Wherever possible do not duplicate external content.
+
+Instead, link to existing official guides and merely provide a lightweight pointer here.
+
+See: https://kubernetes.io/docs/contribute/style/content-guide/#dual-sourced-content
+-->
+
+<!--TODO: cri-o, general manifests-->
+
+For containerd see: [containerd.md](./containerd.md)
+For kubeadm see: [kubeadm.md](./kubeadm.md)

--- a/docs/mirroring/containerd.md
+++ b/docs/mirroring/containerd.md
@@ -1,0 +1,26 @@
+# Mirroring With Containerd
+
+# Identifying Images to Mirror
+
+If you're using containerd as a Kubernetes [CRI] implementation, containerd
+uses the ["pause" image][pause] from Kubernetes in every pod.
+You may want to mirror this critical image to your own host.
+
+The version used by default can be found by `containerd config default | grep sandbox_image`.
+
+# Using Mirrored Images
+
+`containerd` supports configuring mirrors for registry hosts.
+
+If you're using containerd with Kubernetes, see:
+https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration
+
+Additionally, you may want to configure `sandbox_image` under `[plugins."io.containerd.grpc.v1.cri"]`
+to point to your own mirrored image for "pause".
+
+If you're using containerd directly, see:
+https://github.com/containerd/containerd/blob/main/docs/hosts.md
+
+
+[pause]: https://www.ianlewis.org/en/almighty-pause-container
+[CRI]: https://kubernetes.io/docs/concepts/architecture/cri/

--- a/docs/mirroring/kubeadm.md
+++ b/docs/mirroring/kubeadm.md
@@ -1,0 +1,20 @@
+# Mirroring with Kubeadm
+
+## Identifying Images To Mirror
+
+You can use `kubeadm config images list` to get a list of images kubeadm requires.
+
+For more see:
+https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-config/#cmd-config-images-list
+
+## Mirroring Images
+
+See our general list of [mirroring options](./README.md#Mirroring-Images)
+
+## Using Mirrored Images
+
+To use kubeadm with mirrored images, you can pass the `--image-repository` flag
+to [`kubeadm init`][kubeadm init] or the `imageRepository` field of [kubeadm config].
+
+[kubeadm init]: https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/
+[kubeadm config]: https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file


### PR DESCRIPTION
- readme link fixes originally in https://github.com/kubernetes/registry.k8s.io/pull/188
- clarify "infra budget"
- begin stubbing in mirroring guides to help people understand how to identify, mirror, and use mirrors with our images and associated tools and projects

We'll need to add a lot more to the mirroring guide, but I've tried to establish a reasonable structure and begin stubbing in a few I know about off the top of my head.