### PR TITLE
expand kOps and containerd mirroring guides

### DIFF
--- a/docs/mirroring/README.md
+++ b/docs/mirroring/README.md
@@ -32,10 +32,11 @@ kubectl community-images --mirror
 **NOTE**: This will only find images specified in your currently running pods,
 and not for example the "pause" image used to implement pods in containerd / cri-o / dockershim.
 
-Tooling specific guides:
+For specific tools we have these guides:
 
 - For containerd see: [containerd.md](./containerd.md)
 - For kubeadm see: [kubeadm.md](./kubeadm.md)
+- For kOps see: [kOps.md](./kOps.md)
 
 
 ## Mirroring Images
@@ -109,7 +110,13 @@ Instead, link to existing official guides and merely provide a lightweight point
 See: https://kubernetes.io/docs/contribute/style/content-guide/#dual-sourced-content
 -->
 
-<!--TODO: cri-o, general manifests-->
+<!--TODO: cri-o-->
+
+A simple option for many cases is to update the `image` fields in your 
+Kubernetes manifests (deployments, pods, replicasets, etc) to reference
+your mirrored images instead.
+
+For specific tools we have these guides:
 
 - For containerd see: [containerd.md](./containerd.md)
 - For kubeadm see: [kubeadm.md](./kubeadm.md)

--- a/docs/mirroring/containerd.md
+++ b/docs/mirroring/containerd.md
@@ -8,6 +8,14 @@ You may want to mirror this critical image to your own host.
 
 The version used by default can be found by `containerd config default | grep sandbox_image`.
 
+Containerd config is generally at `/etc/containerd/config.toml` and may contain
+a customized "sandbox image" rather than the default, for more details see:
+https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration
+
+## Mirroring Images
+
+See our general list of [mirroring options](./README.md#Mirroring-Images)
+
 # Using Mirrored Images
 
 `containerd` supports configuring mirrors for registry hosts.

--- a/docs/mirroring/kOps.md
+++ b/docs/mirroring/kOps.md
@@ -2,15 +2,26 @@
 
 ## Identifying Images To Mirror
 
-TODO: Help Wanted!
+`kops get assets` can list images and files needed by kOps.
+
+Docs: https://kops.sigs.k8s.io/cli/kops_get_assets/
 
 ## Mirroring Images
 
-See our general list of [mirroring options](./README.md#Mirroring-Images)
+`kops get asssets --copy` can be used to mirror.
+
+See:
+- https://kops.sigs.k8s.io/cli/kops_get_assets/
+- https://kops.sigs.k8s.io/operations/asset-repository/
+
+See also our general list of [mirroring options](./README.md#Mirroring-Images)
 
 ## Using Mirrored Images
 
-You can configure containerd to use registry mirrors for in the kOps cluster spec.
+kOps has documentation for using local assets to create a cluster at:
+https://kops.sigs.k8s.io/operations/asset-repository/
+
+You can also configure containerd to use registry mirrors for in the kOps cluster spec.
 You'll need to add an entry for `"registry.k8s.io"` with your mirror.
 
 Docs: https://kops.sigs.k8s.io/cluster_spec/#registry-mirrors


### PR DESCRIPTION
trying to chip away at these in-between rollouts.