### PR TITLE
geranos: enable uploading config layers

### DIFF
--- a/cmd/geranos/walkimages.go
+++ b/cmd/geranos/walkimages.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/google"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
@@ -120,14 +121,9 @@ func imageToLayers(image v1.Image) ([]v1.Layer, error) {
 	if err != nil {
 		return nil, err
 	}
-	// TODO: upload and use config layers
-	// for now: not uploading them matches rclone syncing from the GCR GCS
-	/*
-			configLayer, err := partial.ConfigLayer(image)
-			if err != nil {
-				return nil, err
-			}
-		return append(layers, configLayer), nil
-	*/
-	return layers, nil
+	configLayer, err := partial.ConfigLayer(image)
+	if err != nil {
+		return nil, err
+	}
+	return append(layers, configLayer), nil
 }


### PR DESCRIPTION
GCR *does* store these in GCS.

I'm not sure why during development I thought these weren't showing up in the GCS bucket ...

These were previously copied in by the rclone script, not uploading them for new images is a regression, though a small one as they're not large and we'll just fallback to serving from AR.

```console
$ crane manifest k8s.gcr.io/pause:3.1 --platform=linux/amd64
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
   "config": {
      "mediaType": "application/vnd.docker.container.image.v1+json",
      "size": 1609,
      "digest": "sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e"
   },
   "layers": [
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 313363,
         "digest": "sha256:67ddbfb20a22d7c0ea0df568069e7ffc42378467402d04f28ecfa244e78c5eb8"
      }
   ]
}

$ curl -I https://storage.googleapis.com/us.artifacts.k8s-artifacts-prod.appspot.com/containers/images/sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e
HTTP/2 200 
x-guploader-uploadid: ADPycdvbKWlH_FRaAJrtvE-kk1EtAxHwosGxCslV11cHZOIbIykt0PHg3zbQXJg9fVBXFQ2K1Lwp9flPTRzzwlI1GTFuInQvwodA
x-goog-generation: 1583287647594206
x-goog-metageneration: 1
x-goog-stored-content-encoding: identity
x-goog-stored-content-length: 1609
x-goog-hash: crc32c=fHyFrQ==
x-goog-hash: md5=67UVyKoLL82Oyt+tqc20dA==
x-goog-storage-class: STANDARD
accept-ranges: bytes
content-length: 1609
server: UploadServer
date: Sun, 26 Mar 2023 00:00:58 GMT
expires: Sun, 26 Mar 2023 01:00:58 GMT
cache-control: public, max-age=3600
age: 3036
last-modified: Wed, 04 Mar 2020 02:07:27 GMT
etag: "ebb515c8aa0b2fcd8ecadfada9cdb474"
content-type: application/octet-stream
alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43

$ curl -I https://prod-registry-k8s-io-ap-northeast-1.s3.dualstack.ap-northeast-1.amazonaws.com/containers/images/sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e
HTTP/1.1 200 OK
x-amz-id-2: c6f3xXtnyeIFhKcN5R9QbgwFGWOSdMQfB1brzVED9ebr5f48lgyAOk5JnVvywcZt1G8p4xBVaQA=
x-amz-request-id: ZHHCA5CMRVX627MT
Date: Sun, 26 Mar 2023 00:50:22 GMT
Last-Modified: Mon, 18 Jul 2022 16:12:09 GMT
ETag: "ebb515c8aa0b2fcd8ecadfada9cdb474"
x-amz-server-side-encryption: AES256
x-amz-meta-mtime: 1583287647.593
x-amz-version-id: eIS5xxFW4R0YpTApzX.OtB8cD5nIZ8kU
Accept-Ranges: bytes
Content-Type: application/octet-stream
Server: AmazonS3
Content-Length: 1609
```