### PR TITLE
deploy staging by overriding image version on terraform

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,14 +6,33 @@ steps:
     args:
       - "push-images"
       - "TAG=$_GIT_TAG"
+  - id: clone-k8s.io
+    name: gcr.io/cloud-builders/git
+    entrypoint: git
+    args:
+    - clone
+    - --filter=tree:0
+    - https://github.com/kubernetes/k8s.io
+    - /k8s.io
+    volumes:
+    # make deploy assumes k8s.io will be at ./../k8s.io
+    # default working dir in cloudbuild is /workspace
+    - name: 'k8sio'
+      path: '/k8s.io'
+    # run immediately
+    waitFor: ['-']
   - id: deploy-staging
-    name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    name: "gcr.io/k8s-staging-infra-tools/k8s-infra:v20220912-7d7ed3258@sha256:48fb967be4c36da551584c3004330c7ce37568e4226ea7233eeb08c979374bc6"
     entrypoint: "/usr/bin/make"
+    volumes:
+    - name: 'k8sio'
+      path: '/k8s.io'
     args:
       - "deploy"
       - "TAG=$_GIT_TAG"
     waitFor:
       - build-image
+      - clone-k8s.io
 substitutions:
   # variables set by kubernetes/test-infra/images/builder
   # set by image-builder to vYYYYMMDD-hash

--- a/hack/make-rules/deploy.sh
+++ b/hack/make-rules/deploy.sh
@@ -19,43 +19,29 @@ set -o errexit -o nounset -o pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 cd "${REPO_ROOT}"
 
+# make sure we have a k8s.io clone for the prod terraform
+k8sio_dir="$(cd "${REPO_ROOT}"/../k8s.io && pwd -P)"
+if [[ ! -d "${k8sio_dir}" ]]; then
+    >&2 echo "Deploying requires a github.com/kubernetes/k8s.io clone at ./../k8s.io"
+    >&2 echo "FAIL"
+    exit 1
+fi
+
+# install crane and get current image digest
 TAG="${TAG:-"$(date +v%Y%m%d)-$(git describe --always --dirty)"}"
-SERVICE_BASENAME="${SERVICE_BASENAME:-k8s-infra-oci-proxy}"
+# TODO: this can't actually be overridden currently
+# the terraform always uses the default here
 IMAGE_REPO="${IMAGE_REPO:-gcr.io/k8s-staging-infra-tools/archeio}"
-PROJECT="${PROJECT:-k8s-infra-oci-proxy}"
+(cd "${REPO_ROOT}"/hack/tools && go build -o "${REPO_ROOT}"/bin/crane github.com/google/go-containerregistry/cmd/crane)
+IMAGE_DIGEST="${IMAGE_DIGEST:-$(bin/crane digest "${IMAGE_REPO}:${TAG}")}"
 
-REGIONS=(
-    asia-east1
-    asia-northeast1
-    asia-northeast2
-    asia-south1
-    australia-southeast1
-    europe-north1
-    europe-southwest1
-    europe-west1
-    europe-west2
-    europe-west4
-    europe-west8
-    europe-west9
-    southamerica-west1
-    us-central1
-    us-east1
-    us-east4
-    us-east5
-    us-south1
-    us-west1
-    us-west2
-)
-
-for REGION in "${REGIONS[@]}"; do
-    gcloud --project="${PROJECT}" \
-        run services update "${SERVICE_BASENAME}-${REGION}" \
-        --image "${IMAGE_REPO}:${TAG}" \
-        --region "${REGION}" \
-        --concurrency 1000 \
-        --max-instances 10 \
-        `# NOTE: should match number of cores configured` \
-        --update-env-vars GOMAXPROCS=1,UPSTREAM_REGISTRY_PATH=k8s-artifacts-prod/images,"UPSTREAM_REGISTRY_ENDPOINT=https://$REGION-docker.pkg.dev" \
-        `# TODO: if we use this to deploy prod, we need to handle this differently` \
-        --args=-v=3
-done
+# cd to staging terraform and apply
+cd "${k8sio_dir}"/infra/gcp/terraform/k8s-infra-oci-proxy
+# use tfswitch to control terraform version based on sources, if available
+if command -v tfswitch >/dev/null; then
+    tfswitch
+fi
+terraform -v
+terraform init
+# NOTE: this must use :? expansion to ensure we will not run with unset variables
+terraform apply -auto-approve -var digest="${IMAGE_DIGEST:?}"


### PR DESCRIPTION
Part of #76 

Auto-deploying staging from the production terraform will let us build confidence that:
1. The staging environment is actually representative of production, just with newer source code
2. We can safely auto-deploy production when changes merge in the k8s.io repo (not here)

We took a shortcut on the first point in particular I'd like to fix that.

I'm less concerned about auto deploy for 2) and to be honest we should have humans on hand to observe changes when we deploy to production considering the scope of potential breakage ...

Depends on https://github.com/kubernetes/k8s.io/pull/5081