### PR TITLE
improve image build times by increasing build machine size

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,6 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
+options:
+  machineType: E2_HIGHCPU_8
 steps:
   - id: build-image
     name: gcr.io/cloud-builders/docker


### PR DESCRIPTION
we need to be able to build this quickly and even with a relatively cheap build the default cloudbuild machine type is single core.

custom sizes take longer to start but run faster.