### PR TITLE
issue template default to kind/support

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -1,6 +1,6 @@
 name: Report an issue with registry.k8s.io
 description: Report a bug encountered while using registry.k8s.io
-labels: ["sig/k8s-infra", "kind/bug", "needs/triage"]
+labels: ["sig/k8s-infra", "kind/support", "needs/triage"]
 body:
   - type: checkboxes
     attributes:


### PR DESCRIPTION
We can `/kind bug` when an issue has evidence that it's a registry bug. we should track support tickets and known bugs seperately. I expect the majority of these to be on the client side and we'll still be trying to respond to those in case they turn out to surface bugs on the server side.

See: first issue filed with the new template https://github.com/kubernetes/registry.k8s.io/issues/214