### PR TITLE
avoid lint timeouts by downloading deps first

### DIFF
--- a/hack/make-rules/lint.sh
+++ b/hack/make-rules/lint.sh
@@ -28,4 +28,5 @@ go build -o "${REPO_ROOT}"/bin/golangci-lint github.com/golangci/golangci-lint/c
 cd "${REPO_ROOT}"
 
 # lint the main module
+go mod download # fetch deps first to avoid including it in timeout
 "${REPO_ROOT}"/bin/golangci-lint --config "${REPO_ROOT}/hack/tools/.golangci.yml" run ./...


### PR DESCRIPTION
should be ~no-op locally for warm development environments, but in CI it ensures module downloads happen prior to linting, so we don't factor that into the linter timeout. this also applies to new development environments that jump straight to `make lint`