### PR TITLE
add e2e tests in addition to cluster e2e testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,16 @@ unit:
 # integration tests
 integration:
 	MODE=integration hack/make-rules/test.sh
-# all tests
+# unit + integration tests
 test:
 	hack/make-rules/test.sh
+# e2e tests
+e2e-test:
+	hack/make-rules/e2e-test.sh
+# e2e tests, but against a local instance instead of staging
+# useful for developing the tests if staging is broken, otherwise use e2e-test
+e2e-test-local:
+	hack/make-rules/e2e-test-local.sh
 ################################################################################
 # ================================= Cleanup ====================================
 # standard cleanup target
@@ -112,4 +119,4 @@ lint:
 shellcheck:
 	hack/make-rules/shellcheck.sh
 #################################################################################
-.PHONY: all archeio build unit integration clean update gofmt verify verify-generated lint shellcheck
+.PHONY: all archeio build unit integration test e2e-test clean update gofmt verify verify-generated lint shellcheck

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -36,6 +36,15 @@ steps:
     waitFor:
       - build-image
       - clone-k8s.io
+  # run quick e2e-tests immediately following deployment, aside from the assorted
+  # testgrid reported periodic results
+  - id: test-staging
+    name: "gcr.io/k8s-staging-infra-tools/k8s-infra:v20220912-7d7ed3258@sha256:48fb967be4c36da551584c3004330c7ce37568e4226ea7233eeb08c979374bc6"
+    entrypoint: "/usr/bin/make"
+    args:
+      - "e2e-test"
+    waitFor:
+      - deploy-staging
 substitutions:
   # variables set by kubernetes/test-infra/images/builder
   # set by image-builder to vYYYYMMDD-hash

--- a/cmd/archeio/docs/testing.md
+++ b/cmd/archeio/docs/testing.md
@@ -9,12 +9,13 @@ These are standard Go unit tests. In addition to typical unit tests with granula
 methods, we also have unit tests covering the HTTP Handlers and full 
 [request handling flow](./request-handling.md).
 
+These tests run on every pull request and must pass before merge.
 
 **This level of coverage must be maintained**, it is imperative that we have robust
 testing in this project that may soon serve all Kubernetes project image downloads.
 We automatically enforce 100% code coverage for archeio sources.
 
-Coverage results are visible by clicking the `pull-oci-proxy-test` context link
+Coverage results are visible by clicking the `pull-registry-test` context link
 at the bottom of the pull request.
 
 Coverage results can be viewed locally by `make test` + open `bin/all-filtered.html`.
@@ -31,12 +32,28 @@ through a running instance using [crane].
 
 `make integration` runs only integration tests.
 
-Because our CI runs primarily in GCP, this currently covers pulling from outside AWS.
+The integration tests are able to exploit running against a local instance without
+a loadbalancer etc in front and fake the client IP address to test provider-IP
+codepaths.
+
+These tests run on every pull request in `pull-registry-test` and must pass before merge.
 
 ## E2E Testing
 
-Changes to archeio are auto-deployed to registry-sandbox.k8s.io and NOT to
-registry.k8s.io. registry.k8s.io serves stable releases.
+Changes to archeio are auto-deployed to the registry-sandbox.k8s.io staging intance
+and NOT to registry.k8s.io. registry.k8s.io serves stable releases.
+
+### e2e tests
+
+We have quick and cheap e2e results using real clients in `make e2e-test`
+and `make e2e-test-local`. We run `make e2e-test` against the staging instance.
+
+These are limited to clients we can run locally and in containerize CI
+without privilege escalation (e.g. [crane] again).
+
+Results are at TODO: add testgrid pointer once these are merged and running
+
+### Cluster e2e Testing
 
 The instance at registry-sandbox.k8s.io has [kops] cluster CI running in AWS 
 pointed at it to validate pulling from AWS. The kops clusters run in random
@@ -45,6 +62,10 @@ regions.
 This E2E CI should be consulted before promoting code to stable release + registry.k8s.io.
 
 Results are visible in [testgrid] at: https://testgrid.k8s.io/sig-k8s-infra-oci-proxy#Summary
+
+The Kubernetes project itself has substantial assorted CI usage of the production instance
+and many CI jobs that primarily exist for other purposes will alert us if pulling from it fails.
+This includes many variations on "real" clusters and image build clients.
 
 [crane]: https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md
 [kops]: https://github.com/kubernetes/kops

--- a/cmd/archeio/internal/e2e/e2e_test.go
+++ b/cmd/archeio/internal/e2e/e2e_test.go
@@ -100,6 +100,10 @@ func goInstall(t *testing.T, tool string) {
 	}
 }
 
+func binPath(name string) string {
+	return filepath.Join(binDir, name)
+}
+
 // common helper for executing test pull and checking output
 func testPull(t *testing.T, tc *testCase, pullCmd *exec.Cmd) {
 	out, err := pullCmd.CombinedOutput()
@@ -123,8 +127,8 @@ func TestE2ECranePull(t *testing.T) {
 		tc := &testCases[i]
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			pullCmd := exec.Command("./crane", "pull", "--verbose", tc.Ref(), "/dev/null")
-			pullCmd.Dir = binDir
+			// nolint:gosec
+			pullCmd := exec.Command(binPath("crane"), "pull", "--verbose", tc.Ref(), "/dev/null")
 			testPull(t, tc, pullCmd)
 		})
 	}

--- a/cmd/archeio/internal/e2e/e2e_test.go
+++ b/cmd/archeio/internal/e2e/e2e_test.go
@@ -1,0 +1,131 @@
+//go:build !noe2e
+// +build !noe2e
+
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// e2e contains end-to-end tests for registry.k8s.io
+package e2e
+
+/*
+	This exists to test against the staging instance of the registry.
+
+	Compare to cmd/archeio/main_test.go which exists to integration test
+	a local instance. There is much overlap but they serve different purposes
+	and cover different aspects.
+
+	The integration tests can run quickly in presubmit and leverage faking
+	locations to cover more codepaths. They do not however cover all interactions
+	with actually deployed infrastructure including e.g. the loadbalancer and
+	WAF rules in front of the deployed instances.
+
+	These tests instead will run from multiple locations and cover the actual
+	production-like infrastructure but cannot fake IP addr there by design as
+	we accurately determine IP there and wouldn't want clients (ab)using this.
+
+	These tests are still expected to be quick and cheap and only cover clients
+	we can run in a containerized, non-privileged environment.
+
+	We have other coverage, see cmd/archeio/docs/testing.md
+*/
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"k8s.io/registry.k8s.io/internal/integration"
+)
+
+var endpoint = "registry-sandbox.k8s.io"
+
+type testCase struct {
+	Name   string
+	Digest string
+}
+
+func (tc *testCase) Ref() string {
+	return endpoint + "/" + tc.Name
+}
+
+var testCases = []testCase{
+	{Name: "pause:3.1", Digest: "sha256:f78411e19d84a252e53bff71a4407a5686c46983a2c2eeed83929b888179acea"},
+	{Name: "pause:3.2", Digest: "sha256:927d98197ec1141a368550822d18fa1c60bdae27b78b0c004f705f548c07814f"},
+	{Name: "pause:3.5", Digest: "sha256:1ff6c18fbef2045af6b9c16bf034cc421a29027b800e4f9b68ae9b1cb3e9ae07"},
+	{Name: "pause:3.9", Digest: "sha256:7031c1b283388d2c2e09b57badb803c05ebed362dc88d84b480cc47f72a21097"},
+}
+
+var repoRoot = ""
+var binDir = ""
+
+func TestMain(m *testing.M) {
+	if e := os.Getenv("REGISTRY_ENDPOINT"); e != "" {
+		endpoint = e
+	}
+	rr, err := integration.ModuleRootDir()
+	if err != nil {
+		panic("failed to get root dir: " + err.Error())
+	}
+	repoRoot = rr
+	binDir = filepath.Join(repoRoot, "bin")
+	if err := os.Chdir(repoRoot); err != nil {
+		panic("failed to chdir to repo root: " + err.Error())
+	}
+	os.Exit(m.Run())
+}
+
+// installs tool to binDir using go install
+func goInstall(t *testing.T, tool string) {
+	buildCmd := exec.Command("go", "install", tool)
+	buildCmd.Env = append(os.Environ(), "GOBIN="+binDir)
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Errorf("Failed to get %q: %v", tool, err)
+		t.Error("Output:")
+		t.Fatal(string(out))
+	}
+}
+
+// common helper for executing test pull and checking output
+func testPull(t *testing.T, tc *testCase, pullCmd *exec.Cmd) {
+	out, err := pullCmd.CombinedOutput()
+	if err != nil {
+		t.Errorf("Failed to pull image: %q with err %v", tc.Name, err)
+		t.Error("Output from command:")
+		t.Fatal(string(out))
+	} else if tc.Digest != "" && !strings.Contains(string(out), tc.Digest) {
+		t.Error("pull output does not contain expected digest")
+		t.Error("Output from command:")
+		t.Fatal(string(out))
+	}
+}
+
+func TestE2ECranePull(t *testing.T) {
+	t.Parallel()
+	// install crane
+	goInstall(t, "github.com/google/go-containerregistry/cmd/crane@latest")
+	// pull test images
+	for i := range testCases {
+		tc := &testCases[i]
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			pullCmd := exec.Command("./crane", "pull", "--verbose", tc.Ref(), "/dev/null")
+			pullCmd.Dir = binDir
+			testPull(t, tc, pullCmd)
+		})
+	}
+}

--- a/hack/make-rules/deploy.sh
+++ b/hack/make-rules/deploy.sh
@@ -38,7 +38,7 @@ TAG="${TAG:-"$(date +v%Y%m%d)-$(git describe --always --dirty)"}"
 # TODO: this can't actually be overridden currently
 # the terraform always uses the default here
 IMAGE_REPO="${IMAGE_REPO:-gcr.io/k8s-staging-infra-tools/archeio}"
-(cd "${REPO_ROOT}"/hack/tools && go build -o "${REPO_ROOT}"/bin/crane github.com/google/go-containerregistry/cmd/crane)
+GOBIN="${REPO_ROOT}/bin" go install github.com/google/go-containerregistry/cmd/crane
 IMAGE_DIGEST="${IMAGE_DIGEST:-$(bin/crane digest "${IMAGE_REPO}:${TAG}")}"
 export IMAGE_DIGEST
 

--- a/hack/make-rules/e2e-test-local.sh
+++ b/hack/make-rules/e2e-test-local.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit -o nounset -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+cd "${REPO_ROOT}"
+
+# normally the e2e tests would run against the staging endpoint
+# this runs them against a local instance so we can test the e2e tests themselves
+# and merge them even if staging is currently broken
+set -x;
+make archeio
+bin/archeio &>"${ARTIFACTS:-./bin}"/archeio-log.txt &
+trap 'kill $(jobs -p)' EXIT
+make e2e-test "REGISTRY_ENDPOINT=localhost:8080"

--- a/hack/make-rules/e2e-test.sh
+++ b/hack/make-rules/e2e-test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# script to run unit / integration tests, with coverage enabled and junit xml output
+set -o errexit -o nounset -o pipefail
+
+# cd to the repo root and setup go
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+cd "${REPO_ROOT}"
+source hack/tools/setup-go.sh
+
+# build gotestsum
+cd 'hack/tools'
+go build -o "${REPO_ROOT}/bin/gotestsum" gotest.tools/gotestsum
+cd "${REPO_ROOT}"
+
+# run e2e tests with junit output
+# TODO: because we expect relatively few packages to have e2e we only
+# test those packages to limit CI noise, but this approach would work with ./...
+# at the cost of reporting lots of no-test packages
+# (versus the combined integration and unit testing results)
+# this is also slightly faster
+(
+  set -x;
+  "${REPO_ROOT}/bin/gotestsum" --junitfile="${REPO_ROOT}/bin/e2e-junit.xml" \
+    -- '-run' '^TestE2E' './cmd/archeio/internal/e2e'
+)
+
+# if we are in CI, copy to the artifact upload location
+if [[ -n "${ARTIFACTS:-}" ]]; then
+  cp "bin/e2e-junit.xml" "${ARTIFACTS:?}/junit.xml"
+fi

--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -36,7 +36,7 @@ go_test_opts=(
   '-coverpkg' 'k8s.io/registry.k8s.io/...'
 )
 if [[ "${MODE}" = 'unit' ]]; then
-  go_test_opts+=('-tags=nointegration')
+  go_test_opts+=('-tags=nointegration,noe2e')
 elif [[ "${MODE}" = 'integration' ]]; then
   go_test_opts+=('-run' '^TestIntegration')
 else

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -4,9 +4,10 @@ go 1.19
 
 require (
 	github.com/golangci/golangci-lint v1.51.1
-	github.com/google/go-containerregistry v0.13.1-0.20230310164735-e94d40893b2d
 	github.com/google/ko v0.13.0
+	golang.org/x/tools v0.7.0
 	gotest.tools/gotestsum v1.9.0
+	k8s.io/apimachinery v0.26.2
 )
 
 require (
@@ -121,6 +122,7 @@ require (
 	github.com/golangci/revgrep v0.0.0-20220804021717-745bb2f7c2e6 // indirect
 	github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/google/go-containerregistry v0.13.1-0.20230310164735-e94d40893b2d // indirect
 	github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/gordonklaus/ineffassign v0.0.0-20230107090616-13ace0543b28 // indirect
@@ -248,7 +250,6 @@ require (
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
-	golang.org/x/tools v0.7.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230209215440-0dfe4f8abfcc // indirect
 	google.golang.org/grpc v1.53.0 // indirect
@@ -258,7 +259,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/tools v0.4.0 // indirect
-	k8s.io/apimachinery v0.26.2 // indirect
 	k8s.io/klog/v2 v2.90.0 // indirect
 	k8s.io/utils v0.0.0-20230115233650-391b47cb4029 // indirect
 	mvdan.cc/gofumpt v0.4.0 // indirect

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -32,7 +32,4 @@ import (
 
 	// image builder
 	_ "github.com/google/ko"
-
-	// for testing
-	_ "github.com/google/go-containerregistry/cmd/crane"
 )


### PR DESCRIPTION
This will allow us to quickly test the staging instance.

After this PR we'll automatically test some quick and cheap e2e tests immediately following staging deploys.

See code comments for why these are different from the integration tests.

This PR also cleans up tracking crane versions in two places

TODO: 
- Add a presubmit test that invokes `make e2e-test-local` (e2e tests against a local instance, for testing the tests) https://github.com/kubernetes/test-infra/pull/29249
- Add periodics on GCP and AWS that invoke `make e2e-test` and add that to the docs https://github.com/kubernetes/test-infra/pull/29249 for GCP
- Expand tests