### PR TITLE
simplify blob cache and improve performance*

### DIFF
--- a/cmd/archeio/internal/app/buckets_integration_test.go
+++ b/cmd/archeio/internal/app/buckets_integration_test.go
@@ -36,21 +36,22 @@ func TestCachedBlobChecker(t *testing.T) {
 		{
 			Name:         "known bucket entry",
 			BlobURL:      bucket + "/containers/images/sha256%3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e",
-			Bucket:       bucket,
-			HashKey:      "3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e",
+			ExpectExists: true,
+		},
+		// to cover the case that we get a cache hit
+		{
+			Name:         "same-known bucket entry",
+			BlobURL:      bucket + "/containers/images/sha256%3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e",
 			ExpectExists: true,
 		},
 		{
 			Name:         "known bucket, bad entry",
-			Bucket:       bucket,
 			BlobURL:      bucket + "/c0ntainers/images/sha256%3Ada86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e",
 			ExpectExists: false,
 		},
 		{
 			Name:         "bogus bucket on domain without webserver",
-			Bucket:       "http://bogus.k8s.io/",
 			BlobURL:      "http://bogus.k8s.io/foo",
-			HashKey:      "b0guS",
 			ExpectExists: false,
 		},
 	}
@@ -60,9 +61,8 @@ func TestCachedBlobChecker(t *testing.T) {
 	for i := range testCases {
 		tc := testCases[i]
 		t.Run(tc.Name, func(t *testing.T) {
-			t.Parallel()
 			url := tc.BlobURL
-			exists := blobs.BlobExists(url, tc.Bucket, tc.HashKey)
+			exists := blobs.BlobExists(url)
 			if exists != tc.ExpectExists {
 				t.Fatalf("expected: %v but got: %v", tc.ExpectExists, exists)
 			}
@@ -72,11 +72,10 @@ func TestCachedBlobChecker(t *testing.T) {
 		tc := testCases[i]
 		t.Run(tc.Name, func(t *testing.T) {
 			url := tc.BlobURL
-			exists := blobs.BlobExists(url, tc.Bucket, tc.HashKey)
+			exists := blobs.BlobExists(url)
 			if exists != tc.ExpectExists {
 				t.Fatalf("expected: %v but got: %v", tc.ExpectExists, exists)
 			}
 		})
 	}
-
 }

--- a/cmd/archeio/internal/app/buckets_test.go
+++ b/cmd/archeio/internal/app/buckets_test.go
@@ -44,3 +44,14 @@ func TestRegionToAWSRegionToHostURL(t *testing.T) {
 		t.Fatalf("received non-empty URL string for made up region \"nonsensical-region\": %q", url)
 	}
 }
+
+func TestBlobCache(t *testing.T) {
+	bc := &blobCache{}
+	bc.Put("foo")
+	if !bc.Get("foo") {
+		t.Fatal("Cache did not contain key we just put")
+	}
+	if bc.Get("bar") {
+		t.Fatal("Cache contained key we did not put")
+	}
+}

--- a/cmd/archeio/internal/app/handlers.go
+++ b/cmd/archeio/internal/app/handlers.go
@@ -149,7 +149,7 @@ func makeV2Handler(rc RegistryConfig, blobs blobChecker) func(w http.ResponseWri
 		bucketURL := awsRegionToHostURL(region, rc.DefaultAWSBaseURL)
 		// this matches GCR's GCS layout, which we will use for other buckets
 		blobURL := bucketURL + "/containers/images/" + digest
-		if blobs.BlobExists(blobURL, bucketURL, digest) {
+		if blobs.BlobExists(blobURL) {
 			// blob known to be available in AWS, redirect client there
 			klog.V(2).InfoS("redirecting blob request to AWS", "path", rPath)
 			http.Redirect(w, r, blobURL, http.StatusTemporaryRedirect)

--- a/cmd/archeio/internal/app/handlers_test.go
+++ b/cmd/archeio/internal/app/handlers_test.go
@@ -147,7 +147,7 @@ type fakeBlobsChecker struct {
 	knownURLs map[string]bool
 }
 
-func (f *fakeBlobsChecker) BlobExists(blobURL, bucket, hashKey string) bool {
+func (f *fakeBlobsChecker) BlobExists(blobURL string) bool {
 	return f.knownURLs[blobURL]
 }
 


### PR DESCRIPTION
\* will use more memory. should have better concurrency and less time spent locking.

The old implementation was written pretty quickly and overly "cleverly", attempting to dedupe the common base URL portion of the string.

We use so little memory right now that this simply isn't a concern, premature optimization :-)

However, we are almost certainly experiencing excessive contention over the blob cache RWMutex. `sync.Map` is more appropriate for append-only-cache type workloads.

Also: while we do want to configure the http client timeout, we don't want to share internal locking structures like the cookiejar, only the transport. A client that simply does not configure a transport gets the shared http.DefaultTransport anyhow.