### PR TITLE
wait for containerd to be ready to avoid CI flakes

### DIFF
--- a/cmd/archeio/internal/e2e/e2e_containerd_linux_test.go
+++ b/cmd/archeio/internal/e2e/e2e_containerd_linux_test.go
@@ -94,6 +94,20 @@ func testE2EContainerdPull(t *testing.T, containerdVersion string) {
 		}
 	})
 
+	// wait for containerd to be ready
+	containerdReady := false
+	for i := 0; i < 5; i++ {
+		// nolint:gosec
+		if err := exec.Command(filepath.Join(installDir, "ctr"), "--address="+socketAddress, "version").Run(); err == nil {
+			containerdReady = true
+			break
+		}
+		time.Sleep(time.Duration(i) * time.Second)
+	}
+	if !containerdReady {
+		t.Fatalf("Failed to wait for containerd to be ready")
+	}
+
 	// pull test images
 	for i := range testCases {
 		tc := &testCases[i]


### PR DESCRIPTION
See failures like https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/registry-sandbox-e2e-gcp/1650849058304036864

Simply due to containerd socket is not ready yet when we start pulling.