### PR TITLE
geranos: skip already uploaded images

### DIFF
--- a/cmd/geranos/walkimages.go
+++ b/cmd/geranos/walkimages.go
@@ -45,7 +45,7 @@ type WalkImageLayersFunc func(ref name.Reference, layers []v1.Layer) error
 // It's also simpler and more efficient.
 //
 // See: https://github.com/opencontainers/distribution-spec/issues/222
-func WalkImageLayersGCP(transport http.RoundTripper, repo name.Repository, walkImageLayers WalkImageLayersFunc) error {
+func WalkImageLayersGCP(transport http.RoundTripper, repo name.Repository, walkImageLayers WalkImageLayersFunc, skipImage func(string) bool) error {
 	g := new(errgroup.Group)
 	// TODO: This is really just an approximation to avoid exceeding typical socket limits
 	// See also quota limits:
@@ -60,6 +60,9 @@ func WalkImageLayersGCP(transport http.RoundTripper, repo name.Repository, walkI
 				digest := digest
 				// google.Walk already walks the child manifests
 				if metadata.MediaType == string(types.DockerManifestList) || metadata.MediaType == string(types.OCIImageIndex) {
+					continue
+				}
+				if skipImage(digest) {
 					continue
 				}
 				ref, err := name.ParseReference(fmt.Sprintf("%s@%s", r, digest))


### PR DESCRIPTION
1. Upload the manifests **after** uploading the layers, to record that we've already uploaded a given image digest to the bucket (with an added backup of the manifest contents instead of an empty key).
2. Skip re-uploading layers when we already have the manifest uploaded.

DOES NOT serve clients from the mirrored manifests.

Should produce a pretty large speedup on the second run. We'll be able to skip making any calls for these images except 1) bulk listing references in the registry 2) one S3 call per manifest to confirm it's already uploaded.