### PR TITLE
specify crane version in deploy.sh

### DIFF
--- a/hack/make-rules/deploy.sh
+++ b/hack/make-rules/deploy.sh
@@ -38,7 +38,7 @@ TAG="${TAG:-"$(date +v%Y%m%d)-$(git describe --always --dirty)"}"
 # TODO: this can't actually be overridden currently
 # the terraform always uses the default here
 IMAGE_REPO="${IMAGE_REPO:-gcr.io/k8s-staging-infra-tools/archeio}"
-GOBIN="${REPO_ROOT}/bin" go install github.com/google/go-containerregistry/cmd/crane
+GOBIN="${REPO_ROOT}/bin" go install github.com/google/go-containerregistry/cmd/crane@latest
 IMAGE_DIGEST="${IMAGE_DIGEST:-$(bin/crane digest "${IMAGE_REPO}:${TAG}")}"
 export IMAGE_DIGEST
 


### PR DESCRIPTION
fixes go attempting to use the module version and finding we don't have all the deps in go.sum

latest is fine, we're using an extremely stable command.