### PR TITLE
use auto go version when installing latest crane for e2e test

### DIFF
--- a/cmd/archeio/internal/e2e/e2e_test.go
+++ b/cmd/archeio/internal/e2e/e2e_test.go
@@ -92,7 +92,7 @@ func TestMain(m *testing.M) {
 // installs tool to binDir using go install
 func goInstall(t *testing.T, tool string) {
 	buildCmd := exec.Command("go", "install", tool)
-	buildCmd.Env = append(os.Environ(), "GOBIN="+binDir)
+	buildCmd.Env = append(os.Environ(), "GOBIN="+binDir, "GOTOOLCHAIN=auto")
 	if out, err := buildCmd.CombinedOutput(); err != nil {
 		t.Errorf("Failed to get %q: %v", tool, err)
 		t.Error("Output:")


### PR DESCRIPTION
before:

```console
$ GOTOOLCHAIN=go1.22.1 make e2e-test
hack/make-rules/e2e-test.sh
+ /Users/bentheelder/go/src/k8s.io/registry.k8s.io/bin/gotestsum --junitfile=/Users/bentheelder/go/src/k8s.io/registry.k8s.io/bin/e2e-junit.xml -- -run '^TestE2E' ./cmd/archeio/internal/e2e
✖  cmd/archeio/internal/e2e (454ms)

=== Failed
=== FAIL: cmd/archeio/internal/e2e TestE2ECranePull (0.06s)
    e2e_test.go:97: Failed to get "github.com/google/go-containerregistry/cmd/crane@latest": exit status 1
    e2e_test.go:98: Output:
    e2e_test.go:99: go: github.com/google/go-containerregistry/cmd/crane@latest: github.com/google/go-containerregistry@v0.20.3 requires go >= 1.23.0 (running go 1.22.1; GOTOOLCHAIN=go1.22.1)
        

DONE 1 tests, 1 failure in 0.883s
make: *** [e2e-test] Error 1
```

after:

```console
$ GOTOOLCHAIN=go1.22.1 make e2e-test
hack/make-rules/e2e-test.sh
+ /Users/bentheelder/go/src/k8s.io/registry.k8s.io/bin/gotestsum --junitfile=/Users/bentheelder/go/src/k8s.io/registry.k8s.io/bin/e2e-junit.xml -- -run '^TestE2E' ./cmd/archeio/internal/e2e
✓  cmd/archeio/internal/e2e (1.931s)

DONE 5 tests in 2.291s
```

fxies #296 