### PR TITLE
add containerd 2.x to e2e tests, do not cache e2e tests

### DIFF
--- a/cmd/archeio/internal/e2e/e2e_containerd_linux_test.go
+++ b/cmd/archeio/internal/e2e/e2e_containerd_linux_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestE2EContainerdPull(t *testing.T) {
 	t.Parallel()
-	containerdVersions := []string{"1.6.20", "1.7.0"}
+	containerdVersions := []string{"1.6.20", "1.7.0", "2.1.3"}
 	for i := range containerdVersions {
 		containerdVersion := containerdVersions[i]
 		t.Run("v"+containerdVersion, func(t *testing.T) {

--- a/hack/make-rules/e2e-test.sh
+++ b/hack/make-rules/e2e-test.sh
@@ -36,7 +36,7 @@ cd "${REPO_ROOT}"
 (
   set -x;
   "${REPO_ROOT}/bin/gotestsum" --junitfile="${REPO_ROOT}/bin/e2e-junit.xml" \
-    -- '-run' '^TestE2E' './cmd/archeio/internal/e2e'
+    -- '-run' '^TestE2E' '-count=1' './cmd/archeio/internal/e2e'
 )
 
 # if we are in CI, copy to the artifact upload location


### PR DESCRIPTION
We don't need to test every client and every version, we're just trying to make sure the registry isn't doing anything that breaks in the wild clients versus our read of the spec.

That said, since we _are_ testing with this client, we should really include the current major version.