### PR TITLE
Drop old stale entry for Riaan as reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,4 +10,3 @@ approvers:
 reviewers:
   - bentheelder
   - hh
-  - riaankl


### PR DESCRIPTION
Riaan's handle has changed - https://github.com/kubernetes/org/pull/4938

Also Riaan is now on CNCF staff and no longer as active in this repo.