### PR TITLE
bump containerd and make arch selection dynamic

### DIFF
--- a/cmd/archeio/internal/e2e/e2e_containerd_linux_test.go
+++ b/cmd/archeio/internal/e2e/e2e_containerd_linux_test.go
@@ -22,13 +22,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 )
 
 func TestE2EContainerdPull(t *testing.T) {
 	t.Parallel()
-	containerdVersions := []string{"1.6.20", "1.7.0", "2.1.3"}
+	containerdVersions := []string{"1.7.29", "2.1.5", "2.2.0"}
 	for i := range containerdVersions {
 		containerdVersion := containerdVersions[i]
 		t.Run("v"+containerdVersion, func(t *testing.T) {
@@ -46,6 +47,7 @@ func testE2EContainerdPull(t *testing.T, containerdVersion string) {
 	installCmd.Env = append(installCmd.Env,
 		"CONTAINERD_VERSION="+containerdVersion,
 		"CONTAINERD_INSTALL_DIR="+installDir,
+		"CONTAINERD_ARCH="+runtime.GOARCH,
 	)
 	installCmd.Stderr = os.Stderr
 	if err := installCmd.Run(); err != nil {

--- a/hack/tools/e2e-setup-containerd.sh
+++ b/hack/tools/e2e-setup-containerd.sh
@@ -23,6 +23,7 @@ cd "${REPO_ROOT}"
 # script inputs, install dir should be versioned
 readonly CONTAINERD_VERSION="${CONTAINERD_VERSION:?}"
 readonly CONTAINERD_INSTALL_DIR="${CONTAINERD_INSTALL_DIR:?}"
+readonly CONTAINERD_ARCH="${CONTAINERD_ARCH:?}"
 
 containerd_path="${CONTAINERD_INSTALL_DIR}/containerd"
 if [[ -f "${containerd_path}" ]] && "${containerd_path}" --version | grep -q "${CONTAINERD_VERSION}"; then
@@ -31,7 +32,7 @@ else
     # downlod containerd to bindir
     mkdir -p "${CONTAINERD_INSTALL_DIR}"
     curl -sSL \
-        "https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-linux-amd64.tar.gz" \
+        "https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-linux-${CONTAINERD_ARCH}.tar.gz" \
     | tar -C "${CONTAINERD_INSTALL_DIR}/" -zxvf - --strip-components=1
 fi
 


### PR DESCRIPTION
Should fix this failure: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/registry-sandbox-e2e-ibm/2000680008049233920

1.6 containerd is EoL now https://containerd.io/releases/