### PR TITLE
Add SIGNATURE_UPSTREAM_ENDPOINT for cosign signature routing

### DIFF
--- a/cmd/archeio/docs/request-handling.md
+++ b/cmd/archeio/docs/request-handling.md
@@ -7,14 +7,16 @@ Requests to archeio follows the following flow:
 1. If it's not a request for `/` or `/privacy` and does not start with `/v2/`: 404 error
 1. For registry API requests, all of which start with `/v2/`:
     - If it's a non-standard API call (`/v2/_catalog`): 404 error
+    - If it's a cosign signature/attestation manifest request (`sha256-*.sig` or `sha256-*.att`) and `SIGNATURE_UPSTREAM_ENDPOINT` is set: Redirect to Signature Upstream
     - If it's a manifest request: Redirect to Upstream Registry
     - If it's from a known GCP IP: Redirect to Upstream Registry
-    -  If it's a known AWS IP AND HEAD request for the layer succeeeds in S3: Redirect to S3
-    -  If it's a known AWS IP AND HEAD fails: Redirect to Upstream Registry
+    - If it's a known AWS IP AND HEAD request for the layer succeeds in S3: Redirect to S3
+    - If it's a known AWS IP AND HEAD fails: Redirect to Upstream Registry
 
 See also: OCI Distribution [Specification](https://github.com/opencontainers/distribution-spec/blob/main/spec.md)
 
 Currently the `Upstream Registry` is a region specific Artifact Registry backend.
+The `Signature Upstream` is an optional single canonical registry (configured via `SIGNATURE_UPSTREAM_ENDPOINT`) used to serve cosign signatures and attestations from one location, avoiding the need to replicate them across all regions.
 
 Or in chart form:
 ```mermaid
@@ -28,7 +30,9 @@ B -->|Yes| E[Serve redirect to registry wiki page]
 A -->|Yes, it is a registry API call| L(Is it an OCI Distribution Standard API Call?)
 L -->|No, it is a non-standard API call.<br>Currently: `/v2/_catalog`.| M[Serve 404 error]
 L -->|Yes, it is a standard API call| F(Is it a blob request?)
-F -->|No| G[Serve redirect to Source Registry on GCP]
+F -->|No| N(Is it a cosign .sig/.att manifest<br/>and SIGNATURE_UPSTREAM_ENDPOINT set?)
+N -->|Yes| O[Serve redirect to Signature Upstream]
+N -->|No| G[Serve redirect to Source Registry on GCP]
 F -->|Yes, it matches known blob request format| H(Is the client IP known to be from GCP?)
 H -->|Yes| G
 H -->|No| I(Does the blob exist in S3?<br/>Check by way of cached HEAD on the bucket we've selected based on client IP.)

--- a/cmd/archeio/internal/app/handlers.go
+++ b/cmd/archeio/internal/app/handlers.go
@@ -29,11 +29,12 @@ import (
 )
 
 type RegistryConfig struct {
-	UpstreamRegistryEndpoint string
-	UpstreamRegistryPath     string
-	InfoURL                  string
-	PrivacyURL               string
-	DefaultAWSBaseURL        string
+	UpstreamRegistryEndpoint  string
+	UpstreamRegistryPath      string
+	SignatureUpstreamEndpoint string
+	InfoURL                   string
+	PrivacyURL                string
+	DefaultAWSBaseURL         string
 }
 
 // MakeHandler returns the root archeio HTTP handler
@@ -78,6 +79,8 @@ func makeV2Handler(rc RegistryConfig, blobs blobChecker) func(w http.ResponseWri
 	// <digest> also cannot contain `/` so we can use a relatively simple and cheap regex
 	// to match blob requests and capture the digest
 	reBlob := regexp.MustCompile("^/v2/.*/blobs/([^/]+:[a-zA-Z0-9=_-]+)$")
+	// matches cosign signature and attestation tag requests
+	reCosignTag := regexp.MustCompile(`^/v2/.*/manifests/sha256-[a-f0-9]{64}\.(sig|att)$`)
 	// initialize map of clientIP to AWS region
 	regionMapper := cloudcidrs.NewIPMapper()
 	// capture these in a http handler lambda
@@ -114,6 +117,13 @@ func makeV2Handler(rc RegistryConfig, blobs blobChecker) func(w http.ResponseWri
 		// check if blob request
 		matches := reBlob.FindStringSubmatch(rPath)
 		if len(matches) != 2 {
+			// check if this is a cosign signature/attestation request
+			if rc.SignatureUpstreamEndpoint != "" && reCosignTag.MatchString(rPath) {
+				redirectURL := signatureRedirectURL(rc, rPath)
+				klog.V(2).InfoS("redirecting cosign signature request to canonical upstream", "path", rPath, "redirect", redirectURL)
+				http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
+				return
+			}
 			// not a blob request so forward it to the main upstream registry
 			redirectURL := upstreamRedirectURL(rc, rPath)
 			klog.V(2).InfoS("redirecting manifest request to upstream registry", "path", rPath, "redirect", redirectURL)
@@ -165,4 +175,8 @@ func makeV2Handler(rc RegistryConfig, blobs blobChecker) func(w http.ResponseWri
 
 func upstreamRedirectURL(rc RegistryConfig, originalPath string) string {
 	return rc.UpstreamRegistryEndpoint + path.Join("/v2/", rc.UpstreamRegistryPath, strings.TrimPrefix(originalPath, "/v2"))
+}
+
+func signatureRedirectURL(rc RegistryConfig, originalPath string) string {
+	return rc.SignatureUpstreamEndpoint + path.Join("/v2/", rc.UpstreamRegistryPath, strings.TrimPrefix(originalPath, "/v2"))
 }

--- a/cmd/archeio/internal/app/handlers_test.go
+++ b/cmd/archeio/internal/app/handlers_test.go
@@ -30,6 +30,7 @@ func TestMakeHandler(t *testing.T) {
 		UpstreamRegistryPath:     "k8s-artifacts-prod/images",
 		InfoURL:                  "https://github.com/kubernetes/k8s.io/tree/main/registry.k8s.io",
 		PrivacyURL:               "https://www.linuxfoundation.org/privacy-policy/",
+		// SignatureUpstreamEndpoint intentionally unset to test fallback behavior
 	}
 	handler := MakeHandler(registryConfig)
 	testCases := []struct {
@@ -107,6 +108,13 @@ func TestMakeHandler(t *testing.T) {
 			ExpectedStatus: http.StatusTemporaryRedirect,
 			ExpectedURL:    "https://us-central1-docker.pkg.dev/v2/k8s-artifacts-prod/images/pause/blobs/sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e",
 		},
+		{
+			// Without SignatureUpstreamEndpoint, .sig tags fall through to the regional upstream
+			Name:           "Cosign .sig tag without canonical upstream falls back to regional",
+			Request:        httptest.NewRequest("GET", "http://localhost:8080/v2/pause/manifests/sha256-da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e.sig", nil),
+			ExpectedStatus: http.StatusTemporaryRedirect,
+			ExpectedURL:    "https://us-central1-docker.pkg.dev/v2/k8s-artifacts-prod/images/pause/manifests/sha256-da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e.sig",
+		},
 	}
 	for i := range testCases {
 		tc := testCases[i]
@@ -153,10 +161,11 @@ func (f *fakeBlobsChecker) BlobExists(blobURL string) bool {
 
 func TestMakeV2Handler(t *testing.T) {
 	registryConfig := RegistryConfig{
-		UpstreamRegistryEndpoint: "https://k8s.gcr.io",
-		UpstreamRegistryPath:     "",
-		InfoURL:                  "https://github.com/kubernetes/k8s.io/tree/main/registry.k8s.io",
-		PrivacyURL:               "https://www.linuxfoundation.org/privacy-policy/",
+		UpstreamRegistryEndpoint:  "https://k8s.gcr.io",
+		UpstreamRegistryPath:      "",
+		SignatureUpstreamEndpoint: "https://us-central1-docker.pkg.dev",
+		InfoURL:                   "https://github.com/kubernetes/k8s.io/tree/main/registry.k8s.io",
+		PrivacyURL:                "https://www.linuxfoundation.org/privacy-policy/",
 	}
 	blobs := fakeBlobsChecker{
 		knownURLs: map[string]bool{
@@ -235,6 +244,36 @@ func TestMakeV2Handler(t *testing.T) {
 			}(),
 			ExpectedStatus: http.StatusTemporaryRedirect,
 			ExpectedURL:    "https://k8s.gcr.io/v2/pause/blobs/sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1234567",
+		},
+		{
+			Name:           "Cosign .sig tag redirects to canonical upstream",
+			Request:        httptest.NewRequest("GET", "http://localhost:8080/v2/pause/manifests/sha256-da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e.sig", nil),
+			ExpectedStatus: http.StatusTemporaryRedirect,
+			ExpectedURL:    "https://us-central1-docker.pkg.dev/v2/pause/manifests/sha256-da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e.sig",
+		},
+		{
+			Name:           "Cosign .att tag redirects to canonical upstream",
+			Request:        httptest.NewRequest("GET", "http://localhost:8080/v2/pause/manifests/sha256-da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e.att", nil),
+			ExpectedStatus: http.StatusTemporaryRedirect,
+			ExpectedURL:    "https://us-central1-docker.pkg.dev/v2/pause/manifests/sha256-da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e.att",
+		},
+		{
+			Name:           "HEAD on .sig tag redirects to canonical upstream",
+			Request:        httptest.NewRequest("HEAD", "http://localhost:8080/v2/pause/manifests/sha256-da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e.sig", nil),
+			ExpectedStatus: http.StatusTemporaryRedirect,
+			ExpectedURL:    "https://us-central1-docker.pkg.dev/v2/pause/manifests/sha256-da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e.sig",
+		},
+		{
+			Name:           "Cosign .sig tag for nested image name",
+			Request:        httptest.NewRequest("GET", "http://localhost:8080/v2/kubernetes/pause/manifests/sha256-da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e.sig", nil),
+			ExpectedStatus: http.StatusTemporaryRedirect,
+			ExpectedURL:    "https://us-central1-docker.pkg.dev/v2/kubernetes/pause/manifests/sha256-da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e.sig",
+		},
+		{
+			Name:           "Tag list still redirects to regional upstream",
+			Request:        httptest.NewRequest("GET", "http://localhost:8080/v2/pause/tags/list", nil),
+			ExpectedStatus: http.StatusTemporaryRedirect,
+			ExpectedURL:    "https://k8s.gcr.io/v2/pause/tags/list",
 		},
 	}
 	for i := range testCases {

--- a/cmd/archeio/main.go
+++ b/cmd/archeio/main.go
@@ -42,11 +42,12 @@ func main() {
 
 	// make it possible to override k8s.gcr.io without rebuilding in the future
 	registryConfig := app.RegistryConfig{
-		UpstreamRegistryEndpoint: getEnv("UPSTREAM_REGISTRY_ENDPOINT", "https://us-central1-docker.pkg.dev"),
-		UpstreamRegistryPath:     getEnv("UPSTREAM_REGISTRY_PATH", "k8s-artifacts-prod/images"),
-		InfoURL:                  "https://github.com/kubernetes/registry.k8s.io",
-		PrivacyURL:               "https://www.linuxfoundation.org/privacy-policy/",
-		DefaultAWSBaseURL:        getEnv("DEFAULT_AWS_BASE_URL", "https://prod-registry-k8s-io-us-east-1.s3.dualstack.us-east-1.amazonaws.com"),
+		UpstreamRegistryEndpoint:  getEnv("UPSTREAM_REGISTRY_ENDPOINT", "https://us-central1-docker.pkg.dev"),
+		UpstreamRegistryPath:      getEnv("UPSTREAM_REGISTRY_PATH", "k8s-artifacts-prod/images"),
+		SignatureUpstreamEndpoint: getEnv("SIGNATURE_UPSTREAM_ENDPOINT", ""),
+		InfoURL:                   "https://github.com/kubernetes/registry.k8s.io",
+		PrivacyURL:                "https://www.linuxfoundation.org/privacy-policy/",
+		DefaultAWSBaseURL:         getEnv("DEFAULT_AWS_BASE_URL", "https://prod-registry-k8s-io-us-east-1.s3.dualstack.us-east-1.amazonaws.com"),
 	}
 
 	// configure server with reasonable timeout


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Adds routing logic to redirect cosign signature (.sig) and attestation (.att) manifest requests to a single canonical upstream registry instead of the per-region upstream. This allows the image promoter to write signatures to one registry and have them available globally through registry.k8s.io. Controlled via the new `SIGNATURE_UPSTREAM_ENDPOINT` environment variable; when unset, behavior is unchanged.

#### Which issue(s) this PR fixes:
Ref kubernetes-sigs/promo-tools#1762

#### Special notes for your reviewer:
Related PRs:
- kubernetes-sigs/promo-tools#1829 (remove signature replication)
- https://github.com/kubernetes/k8s.io/pull/9413 (deploy SIGNATURE_UPSTREAM_ENDPOINT)
- kubernetes/test-infra#36909 (remove Prow replication job)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```