### PR TITLE
Drop me-south-1 S3 bucket, fall back to me-central-1

### DIFF
--- a/cmd/archeio/internal/app/buckets.go
+++ b/cmd/archeio/internal/app/buckets.go
@@ -115,12 +115,9 @@ func awsRegionToHostURL(region, defaultURL string) string {
 	// Israel (Tel Aviv)
 	case "il-central-1":
 		return "https://prod-registry-k8s-io-il-central-1.s3.dualstack.il-central-1.amazonaws.com"
-	// Middle East (UAE)
-	case "me-central-1":
+	// Middle East (UAE) and Middle East (Bahrain)
+	case "me-central-1", "me-south-1":
 		return "https://prod-registry-k8s-io-me-central-1.s3.dualstack.me-central-1.amazonaws.com"
-	// Middle East (Bahrain)
-	case "me-south-1":
-		return "https://prod-registry-k8s-io-me-south-1.s3.dualstack.me-south-1.amazonaws.com"
 	// Mexico (Central)
 	case "mx-central-1":
 		return "https://prod-registry-k8s-io-mx-central-1.s3.dualstack.mx-central-1.amazonaws.com"


### PR DESCRIPTION
/kind bug

The me-south-1 (Bahrain) S3 bucket is unreachable, causing integration test failures in CI. This maps me-south-1 traffic to the nearby me-central-1 (UAE) bucket instead.