### PR TITLE
return 404s very early

### DIFF
--- a/cmd/archeio/docs/request-handling.md
+++ b/cmd/archeio/docs/request-handling.md
@@ -10,6 +10,7 @@ Requests to archeio follows the following flow:
    - If it's the version check (`/v2/` or `/v2`) without a `Bearer` token: 401 error with a `WWW-Authenticate` challenge pointing at `/token`
    - If it's the version check with a `Bearer` token: 200 OK
    - If it's a non-standard API call (`/v2/_catalog`): 404 error
+   - If the image's top level repository did not exist upstream at startup: 404 error (see [Known Repositories](#known-repositories) below)
    - If it's a cosign signature/attestation manifest request (`sha256-*.sig` or `sha256-*.att`) and `SIGNATURE_UPSTREAM_ENDPOINT` is set: Redirect to Signature Upstream
    - If it's a manifest request: Redirect to Upstream Registry
    - If it's from a known GCP IP: Redirect to Upstream Registry
@@ -20,6 +21,24 @@ See also: OCI Distribution [Specification](https://github.com/opencontainers/dis
 
 Currently the `Upstream Registry` is a region specific Artifact Registry backend.
 The `Signature Upstream` is an optional single canonical registry (configured via `SIGNATURE_UPSTREAM_ENDPOINT`) used to serve cosign signatures and attestations from one location, avoiding the need to replicate them across all regions.
+
+## Known Repositories
+
+At startup archeio lists the repositories available upstream from
+`${UPSTREAM_REGISTRY_ENDPOINT}/v2/${UPSTREAM_REGISTRY_PATH}/tags/list`, using the
+`child` field GCR / Artifact Registry add to the tags list response, e.g.
+<https://us-central1-docker.pkg.dev/v2/k8s-artifacts-prod/images/tags/list>.
+
+Requests for an image whose first name segment is not in that list are served a
+`404` directly, instead of redirecting the client to an upstream `404`.
+
+Notes:
+
+- Only immediate children are listed, so nested images such as
+  `sig-storage/csi-provisioner` are matched by their `sig-storage` parent.
+- The list is a startup snapshot, it is not refreshed. Images added upstream
+  afterwards require a restart (Cloud Run revisions are short lived).
+- If the listing fails archeio serves without this check rather than not serving.
 
 ## Trace Correlation
 

--- a/cmd/archeio/internal/app/handlers.go
+++ b/cmd/archeio/internal/app/handlers.go
@@ -54,10 +54,14 @@ const (
 // upstream registry should be the url to the primary registry
 // archeio is fronting.
 //
+// knownRepositories is the set of top level repositories available upstream,
+// see ListUpstreamRepositories. Requests for anything else are served 404.
+// Pass nil / empty to serve without this check.
+//
 // Exact behavior should be documented in docs/request-handling.md
-func MakeHandler(rc RegistryConfig) http.Handler {
+func MakeHandler(rc RegistryConfig, knownRepositories map[string]struct{}) http.Handler {
 	blobs := newCachedBlobChecker()
-	doV2 := makeV2Handler(rc, blobs)
+	doV2 := makeV2Handler(rc, blobs, knownRepositories)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// only allow GET, HEAD
 		// this is all a client needs to pull images
@@ -85,7 +89,7 @@ func MakeHandler(rc RegistryConfig) http.Handler {
 	})
 }
 
-func makeV2Handler(rc RegistryConfig, blobs blobChecker) func(w http.ResponseWriter, r *http.Request) {
+func makeV2Handler(rc RegistryConfig, blobs blobChecker, knownRepositories map[string]struct{}) func(w http.ResponseWriter, r *http.Request) {
 	// matches blob requests, captures the requested blob hash
 	// https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pull
 	// Blobs are at `/v2/<name>/blobs/<digest>`
@@ -147,6 +151,17 @@ func makeV2Handler(rc RegistryConfig, blobs blobChecker) func(w http.ResponseWri
 		if rPath == "/v2/_catalog" {
 			http.Error(w, "_catalog is not supported", http.StatusNotFound)
 			return
+		}
+
+		// fail fast for images that did not exist upstream at startup instead
+		// of sending the client on a redirect that can only end in a 404
+		if len(knownRepositories) > 0 {
+			repository := topLevelRepository(rPath)
+			if _, known := knownRepositories[repository]; !known {
+				klog.V(2).InfoS("serving 404 for unknown repository", "path", rPath, "repository", repository, "traceID", traceID)
+				http.Error(w, "repository does not exist", http.StatusNotFound)
+				return
+			}
 		}
 
 		// resolve the client IP and cloud/region info once, used for backend

--- a/cmd/archeio/internal/app/handlers_test.go
+++ b/cmd/archeio/internal/app/handlers_test.go
@@ -36,7 +36,7 @@ func TestMakeHandler(t *testing.T) {
 		PrivacyURL:               "https://www.linuxfoundation.org/privacy-policy/",
 		// SignatureUpstreamEndpoint intentionally unset to test fallback behavior
 	}
-	handler := MakeHandler(registryConfig)
+	handler := MakeHandler(registryConfig, nil)
 	testCases := []struct {
 		Name           string
 		Request        *http.Request
@@ -270,7 +270,10 @@ func TestMakeV2Handler(t *testing.T) {
 			"https://prod-registry-k8s-io-us-west-1.s3.dualstack.us-west-1.amazonaws.com/containers/images/sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e":           true,
 		},
 	}
-	handler := makeV2Handler(registryConfig, &blobs)
+	handler := makeV2Handler(registryConfig, &blobs, map[string]struct{}{
+		"pause":      {},
+		"kubernetes": {},
+	})
 	testCases := []struct {
 		Name           string
 		Request        *http.Request
@@ -366,6 +369,12 @@ func TestMakeV2Handler(t *testing.T) {
 			ExpectedStatus: http.StatusTemporaryRedirect,
 			ExpectedURL:    "https://k8s.gcr.io/v2/pause/tags/list",
 		},
+		{
+			Name:           "Return 404s for non existent images",
+			Request:        httptest.NewRequest("GET", "http://localhost:8080/v2/foobar/tags/list", nil),
+			ExpectedStatus: http.StatusNotFound,
+			ExpectedURL:    "",
+		},
 	}
 	for i := range testCases {
 		tc := testCases[i]
@@ -412,7 +421,7 @@ func TestTraceIDCorrelation(t *testing.T) {
 			"https://prod-registry-k8s-io-eu-west-3.s3.dualstack.eu-west-3.amazonaws.com/containers/images/sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e": true,
 		},
 	}
-	handler := makeV2Handler(registryConfig, &blobs)
+	handler := makeV2Handler(registryConfig, &blobs, nil)
 
 	const wantTraceID = "4bf92f3577b34da6a3ce929d0e0e4736"
 	testCases := []struct {
@@ -496,7 +505,7 @@ func TestPullSessionCorrelation(t *testing.T) {
 	registryConfig := RegistryConfig{
 		UpstreamRegistryEndpoint: "https://k8s.gcr.io",
 	}
-	handler := MakeHandler(registryConfig)
+	handler := MakeHandler(registryConfig, nil)
 
 	do := func(method, target, authorization string) *http.Response {
 		r := httptest.NewRequest(method, target, nil)

--- a/cmd/archeio/internal/app/repositories.go
+++ b/cmd/archeio/internal/app/repositories.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+)
+
+// maxRepositoryListBytes bounds how much of the repository listing response
+// we are willing to read
+const maxRepositoryListBytes = 8 << 20
+
+// ListUpstreamRepositories returns the set of repositories hosted under the
+// configured upstream registry path, e.g.
+// https://us-central1-docker.pkg.dev/v2/k8s-artifacts-prod/images/tags/list
+//
+// It relies on the `child` field GCR and Artifact Registry add to the tags
+// list response. Only immediate children are listed, so nested images like
+// sig-storage/csi-provisioner are represented by their sig-storage parent.
+//
+// This is meant to be called once at startup, see MakeHandler.
+func ListUpstreamRepositories(rc RegistryConfig) (map[string]struct{}, error) {
+	listURL := rc.UpstreamRegistryEndpoint + path.Join("/v2/", rc.UpstreamRegistryPath, "tags/list")
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	resp, err := client.Get(listURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d listing repositories at %s", resp.StatusCode, listURL)
+	}
+	var listing struct {
+		Child []string `json:"child"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxRepositoryListBytes)).Decode(&listing); err != nil {
+		return nil, err
+	}
+	if len(listing.Child) == 0 {
+		return nil, errors.New("upstream registry listed no repositories")
+	}
+	repositories := make(map[string]struct{}, len(listing.Child))
+	for _, child := range listing.Child {
+		repositories[child] = struct{}{}
+	}
+	return repositories, nil
+}
+
+// topLevelRepository returns the first segment of the image name in a
+// /v2/<name>/... request path, or "" if there is none
+func topLevelRepository(requestPath string) string {
+	rest, ok := strings.CutPrefix(requestPath, "/v2/")
+	if !ok {
+		return ""
+	}
+	repository, _, _ := strings.Cut(rest, "/")
+	return repository
+}

--- a/cmd/archeio/internal/app/repositories_test.go
+++ b/cmd/archeio/internal/app/repositories_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListUpstreamRepositories(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		Name        string
+		Status      int
+		Body        string
+		ExpectError bool
+		Expected    []string
+	}{
+		{
+			Name:     "child repositories",
+			Status:   http.StatusOK,
+			Body:     `{"child":["pause","sig-storage"],"tags":[],"manifest":{}}`,
+			Expected: []string{"pause", "sig-storage"},
+		},
+		{
+			Name:        "no children",
+			Status:      http.StatusOK,
+			Body:        `{"child":[]}`,
+			ExpectError: true,
+		},
+		{
+			Name:        "invalid json",
+			Status:      http.StatusOK,
+			Body:        `not json`,
+			ExpectError: true,
+		},
+		{
+			Name:        "non-OK status",
+			Status:      http.StatusForbidden,
+			Body:        `{}`,
+			ExpectError: true,
+		},
+	}
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			var gotPath string
+			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				w.WriteHeader(tc.Status)
+				_, _ = w.Write([]byte(tc.Body))
+			}))
+			defer s.Close()
+
+			repositories, err := ListUpstreamRepositories(RegistryConfig{
+				UpstreamRegistryEndpoint: s.URL,
+				UpstreamRegistryPath:     "k8s-artifacts-prod/images",
+			})
+			if tc.ExpectError {
+				if err == nil {
+					t.Fatalf("expected error but got repositories: %v", repositories)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotPath != "/v2/k8s-artifacts-prod/images/tags/list" {
+				t.Fatalf("unexpected list path: %q", gotPath)
+			}
+			if len(repositories) != len(tc.Expected) {
+				t.Fatalf("expected %d repositories but got %v", len(tc.Expected), repositories)
+			}
+			for _, expected := range tc.Expected {
+				if _, ok := repositories[expected]; !ok {
+					t.Fatalf("expected repository %q in %v", expected, repositories)
+				}
+			}
+		})
+	}
+}
+
+func TestListUpstreamRepositoriesUnreachable(t *testing.T) {
+	t.Parallel()
+	if _, err := ListUpstreamRepositories(RegistryConfig{
+		UpstreamRegistryEndpoint: "http://bogus.k8s.io",
+	}); err == nil {
+		t.Fatal("expected error for unreachable registry")
+	}
+}
+
+func TestTopLevelRepository(t *testing.T) {
+	t.Parallel()
+	testCases := map[string]string{
+		"/v2/pause/manifests/latest":                  "pause",
+		"/v2/sig-storage/csi-provisioner/tags/list":   "sig-storage",
+		"/v2/pause/blobs/sha256:da86e6ba6ca197bf6bca": "pause",
+		"/v2/pause": "pause",
+		"/v2/":      "",
+		"/v2":       "",
+		"/token":    "",
+	}
+	for requestPath, expected := range testCases {
+		if got := topLevelRepository(requestPath); got != expected {
+			t.Fatalf("expected %q for %q but got %q", expected, requestPath, got)
+		}
+	}
+}
+
+func TestV2HandlerUnknownRepository(t *testing.T) {
+	t.Parallel()
+	registryConfig := RegistryConfig{
+		UpstreamRegistryEndpoint: "https://k8s.gcr.io",
+	}
+	knownRepositories := map[string]struct{}{
+		"pause":       {},
+		"sig-storage": {},
+	}
+	handler := makeV2Handler(registryConfig, &fakeBlobsChecker{}, knownRepositories)
+
+	testCases := []struct {
+		Name           string
+		Target         string
+		ExpectedStatus int
+	}{
+		{
+			Name:           "known repository",
+			Target:         "http://localhost:8080/v2/pause/manifests/latest",
+			ExpectedStatus: http.StatusTemporaryRedirect,
+		},
+		{
+			Name:           "known nested repository",
+			Target:         "http://localhost:8080/v2/sig-storage/csi-provisioner/manifests/latest",
+			ExpectedStatus: http.StatusTemporaryRedirect,
+		},
+		{
+			Name:           "unknown repository manifest",
+			Target:         "http://localhost:8080/v2/does-not-exist/manifests/latest",
+			ExpectedStatus: http.StatusNotFound,
+		},
+		{
+			Name:           "unknown repository blob",
+			Target:         "http://localhost:8080/v2/does-not-exist/blobs/sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e",
+			ExpectedStatus: http.StatusNotFound,
+		},
+		{
+			// the API version check must still work
+			Name:           "/v2/ check",
+			Target:         "http://localhost:8080/v2/",
+			ExpectedStatus: http.StatusUnauthorized,
+		},
+	}
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			recorder := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", tc.Target, nil)
+			r.RemoteAddr = "35.180.1.1:888"
+			handler(recorder, r)
+			if status := recorder.Result().StatusCode; status != tc.ExpectedStatus {
+				t.Fatalf("expected status %d but got %d", tc.ExpectedStatus, status)
+			}
+		})
+	}
+}

--- a/cmd/archeio/main.go
+++ b/cmd/archeio/main.go
@@ -58,11 +58,21 @@ func main() {
 		DefaultAWSBaseURL:         getEnv("DEFAULT_AWS_BASE_URL", "https://d1be1w964nk82h.cloudfront.net"),
 	}
 
+	// snapshot the repositories that exist upstream so we can 404 requests for
+	// images that don't exist instead of redirecting clients to a 404
+	// this is best effort: if we can't list them we serve without the check
+	knownRepositories, err := app.ListUpstreamRepositories(registryConfig)
+	if err != nil {
+		klog.ErrorS(err, "failed to list upstream repositories, serving without unknown image filtering")
+	} else {
+		klog.InfoS("listed upstream repositories", "count", len(knownRepositories))
+	}
+
 	// configure server with reasonable timeout
 	// we only serve redirects, 10s should be sufficient
 	server := &http.Server{
 		Addr:              ":" + port,
-		Handler:           app.MakeHandler(registryConfig),
+		Handler:           app.MakeHandler(registryConfig, knownRepositories),
 		ReadTimeout:       10 * time.Second,
 		ReadHeaderTimeout: 2 * time.Second,
 	}


### PR DESCRIPTION
I rolled out the analytics change in prod, and we have some very interesting observations.

We have a lot of requests for paths we don't serve. The rate of 404s served by CF via existence checks is very high.


Here is a good example:

```jsonc
// Cloudfront error, the client here is Cloud Run
{
    "date": "2026-08-15",
    "time": "20:13:38",
    "x-edge-location": "ORD56-P9",
    "sc-bytes": "241",
    "c-ip": "2600:1900:0:2d11::1300",
    "cs-method": "HEAD",
    "cs(Host)": "d1be1w964nk82h.cloudfront.net",
    "cs-uri-stem": "/containers/images/sha256:59bae3d15ef444fe0d5023d5484e0b3160ef306c5b8a4e5c719cbb034487abb2",
    "sc-status": "404",
    "cs(Referer)": "-",
    "cs(User-Agent)": "Go-http-client/2.0",
    "cs-uri-query": "rid=4be8e401b38d2779f79c74fb042c39f4",
    "cs(Cookie)": "-",
    "x-edge-result-type": "Error",
    "x-edge-request-id": "wlt2Aob6BkRk08H_oC2QslaNwUkOic1eBI5D2tIxVBe-HL8mBwwx8A==",
    "x-host-header": "cdn.registry.k8s.io",
    "cs-protocol": "https",
    "cs-bytes": "105",
    "time-taken": "0.050",
    "x-forwarded-for": "-",
    "ssl-protocol": "TLSv1.3",
    "ssl-cipher": "TLS_AES_128_GCM_SHA256",
    "x-edge-response-result-type": "Error",
    "cs-protocol-version": "HTTP/2.0",
    "fle-status": "-",
    "fle-encrypted-fields": "-",
    "c-port": "4496",
    "time-to-first-byte": "0.050",
    "x-edge-detailed-result-type": "Error",
    "sc-content-type": "application/xml",
    "sc-content-len": "-",
    "sc-range-start": "-",
    "sc-range-end": "-"
}
```

When we lookup the rid in GCP, we have this:

4be8e401b38d2779f79c74fb042c39f4

It's a misbehaving Artifactory Client, but because it requests a digest, archeio will immediately hit CloudFront for an existence check, which will fail.

```jsonc
{
  "insertId": "6a80c8720007f215aadd42c8",
  "httpRequest": {
    "requestMethod": "GET",
    "requestUrl": "https://registry.k8s.io/v2/product/prod.billing.rating_cm_cm-core-dp-builder/blobs/sha256:59bae3d15ef444fe0d5023d5484e0b3160ef306c5b8a4e5c719cbb034487abb2",
    "requestSize": "719",
    "status": 307,
    "responseSize": "640",
    "userAgent": "Artifactory/7.125.14 82514900",
    "remoteIp": "198.49.X.X",
    "serverIp": "34.96.108.209",
    "latency": "0.068033014s",
    "protocol": "HTTP/1.1"
  },
  "resource": {
    "type": "cloud_run_revision",
    "labels": {
      "revision_name": "k8s-infra-oci-proxy-prod-us-central1-00021-n8d",
      "project_id": "k8s-infra-oci-proxy-prod",
      "configuration_name": "k8s-infra-oci-proxy-prod-us-central1",
      "service_name": "k8s-infra-oci-proxy-prod-us-central1",
      "location": "us-central1"
    }
  },
  "timestamp": "2026-08-15T20:13:38.450533Z",
  "severity": "INFO",
  "labels": {
    "instanceId": "001548f72903ebcdbb0a639fa9148a39147e5ba146cc2790f52c93951a69b64bb6215c0e15778badf2b9c541e211ab0b913c3daa95db05ab3f0166dbb0b0960d2095f8ea623ef0ace37c22c40629"
  },
  "logName": "projects/k8s-infra-oci-proxy-prod/logs/run.googleapis.com%2Frequests",
  "trace": "projects/k8s-infra-oci-proxy-prod/traces/4be8e401b38d2779f79c74fb042c39f4",
  "receiveTimestamp": "2026-08-15T20:13:38.845070542Z",
  "spanId": "5e0cbc10ad72ed90"
},
{
  "insertId": "6a80c8720007ef3de3502427",
  "jsonPayload": {
    "cloud": "external",
    "traceID": "4be8e401b38d2779f79c74fb042c39f4",
    "image": "product/prod.billing.rating_cm_cm-core-dp-builder",
    "backend": "upstream",
    "timestamp": "2026-08-15T20:13:38.518480666Z",
    "caller": "app/analytics.go:70",
    "region": "external",
    "type": "blob",
    "message": "image_pull",
    "service": "k8s-infra-oci-proxy-prod-us-central1",
    "asn": "26716",
    "userAgent": "Artifactory/7.125.14 82514900",
    "reference": "sha256:59bae3d15ef444fe0d5023d5484e0b3160ef306c5b8a4e5c719cbb034487abb2"
  },
  "resource": {
    "type": "cloud_run_revision",
    "labels": {
      "configuration_name": "k8s-infra-oci-proxy-prod-us-central1",
      "project_id": "k8s-infra-oci-proxy-prod",
      "service_name": "k8s-infra-oci-proxy-prod-us-central1",
      "revision_name": "k8s-infra-oci-proxy-prod-us-central1-00021-n8d",
      "location": "us-central1"
    }
  },
  "timestamp": "2026-08-15T20:13:38.519997Z",
  "severity": "DEBUG",
  "labels": {
    "instanceId": "001548f72903ebcdbb0a639fa9148a39147e5ba146cc2790f52c93951a69b64bb6215c0e15778badf2b9c541e211ab0b913c3daa95db05ab3f0166dbb0b0960d2095f8ea623ef0ace37c22c40629"
  },
  "logName": "projects/k8s-infra-oci-proxy-prod/logs/run.googleapis.com%2Fstderr",
  "receiveTimestamp": "2026-08-15T20:13:38.633075286Z"
}
```